### PR TITLE
Enhancement: Sort users on admin page using updatedAt

### DIFF
--- a/apps/app/app/pages/app/admin/users.vue
+++ b/apps/app/app/pages/app/admin/users.vue
@@ -13,7 +13,7 @@ const updateLoading = ref(false)
 const deleteLoading = ref(false)
 
 const filteredUsers = computed(() => {
-  if (!search.value) return users.value
+  if (!search.value) return users.value?.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
   return users.value!.filter((user: publicUser) => user.username.toLowerCase().includes(search.value.toLowerCase()))
 })
 

--- a/apps/app/server/api/admin/users/index.get.ts
+++ b/apps/app/server/api/admin/users/index.get.ts
@@ -1,5 +1,9 @@
 export default eventHandler(async () => {
-  const users = await prisma.user.findMany()
+  const users = await prisma.user.findMany({
+    orderBy: {
+      updatedAt: 'desc',
+    },
+  })
   return users.map((user) => {
     return formatUser(user)
   })


### PR DESCRIPTION
Fixes #250

Sort users on the admin page by `updatedAt`.

* Modify `filteredUsers` computed property in `apps/app/app/pages/app/admin/users.vue` to sort users by `updatedAt` in descending order.
* Add sorting logic to the database query in `apps/app/server/api/admin/users/index.get.ts` to fetch users sorted by `updatedAt` in descending order.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HugoRCD/shelve/issues/250?shareId=aeb566d7-678b-47ca-adb7-fdccf605e409).