### PR TITLE
feat: Add community docker-compose configuration for one-click self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,33 @@ To self-host the Shelve application using the Docker image available on GitHub, 
 
 Ensure you have Docker installed and running on your machine before executing these commands. For more information on Docker, refer to the [official Docker documentation](https://docs.docker.com/get-docker/).
 
+## Self-Hosting with docker-compose
+
+To self-host the Shelve application using the community `docker-compose` configuration, follow these steps:
+
+1. **Clone the Repository**:
+    ```sh
+    git clone https://github.com/HugoRCD/shelve.git
+    cd shelve
+    ```
+
+2. **Copy the Example Environment File**:
+    ```sh
+    cp apps/shelve/.env.example apps/shelve/.env
+    ```
+
+3. **Update Environment Variables**:
+   Edit the `apps/shelve/.env` file and update the necessary environment variables.
+
+4. **Run docker-compose**:
+    ```sh
+    docker-compose -f docker-compose.community.yml up -d
+    ```
+
+5. **Access the Application**:
+   Open your browser and navigate to `http://localhost:3000` to access the Shelve application.
+
+Ensure you have Docker and docker-compose installed and running on your machine before executing these commands. For more information on Docker and docker-compose, refer to the official Docker documentation.
 
 <!-- automd:fetch url="gh:hugorcd/markdown/main/src/contributions.md" -->
 

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -1,0 +1,78 @@
+services:
+  shelve_app:
+    container_name: shelve_app
+    build:
+      context: .
+      dockerfile: ./apps/shelve/Dockerfile
+    restart: always
+    env_file:
+      - ./apps/shelve/.env
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - NUXT_PRIVATE_REDIS_URL=${NUXT_PRIVATE_REDIS_URL:-redis://shelve_redis:6379}
+      - NUXT_PRIVATE_ENCRYPTION_KEY=${NUXT_PRIVATE_ENCRYPTION_KEY}
+      - NUXT_SESSION_PASSWORD=${NUXT_SESSION_PASSWORD}
+      - NUXT_OAUTH_GITHUB_CLIENT_ID=${NUXT_OAUTH_GITHUB_CLIENT_ID}
+      - NUXT_OAUTH_GITHUB_CLIENT_SECRET=${NUXT_OAUTH_GITHUB_CLIENT_SECRET}
+      - NUXT_PUBLIC_APP_URL=${NUXT_PUBLIC_APP_URL}
+      - NUXT_PRIVATE_RESEND_API_KEY=${NUXT_PRIVATE_RESEND_API_KEY}
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/api/hello" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+    networks:
+      - shelve-network
+  shelve_db:
+    container_name: shelve_db
+    image: postgres:17-alpine
+    restart: always
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "postgres" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - shelve-network
+  shelve_redis:
+    container_name: shelve_redis
+    image: redis:7.4-alpine
+    restart: always
+    volumes:
+      - redis:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - shelve-network
+
+networks:
+  shelve-network:
+    driver: bridge
+
+volumes:
+  postgres:
+  redis:


### PR DESCRIPTION
Fixes #284

Add a new `docker-compose.community.yml` file and update `README.md` for community self-hosting.

* **docker-compose.community.yml**:
  - Create a new file with configurations for `shelve_app`, `shelve_db`, and `shelve_redis` services.
  - Include health checks, logging options, and resource limits for services.
  - Define a custom network and volumes for `postgres` and `redis`.

* **README.md**:
  - Add a new section for self-hosting with `docker-compose`.
  - Provide step-by-step instructions for cloning the repository, copying the example environment file, updating environment variables, running `docker-compose`, and accessing the application.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HugoRCD/shelve/issues/284?shareId=66d77f1a-a6a3-4607-9fc5-835f7cd9bfc2).