### PR TITLE
feat: Add admin routing in UserDropdown for easier use in mobile

### DIFF
--- a/apps/shelve/app/components/UserDropdown.vue
+++ b/apps/shelve/app/components/UserDropdown.vue
@@ -1,6 +1,17 @@
 <script setup lang="ts">
+import { Role } from '@shelve/types'
+
 const navigations = getNavigation('app')
 const navItem = navigations.map((nav) => {
+  return {
+    label: nav.name,
+    icon: nav.icon,
+    to: nav.path,
+  }
+})
+
+const adminNavigations = getNavigation('admin')
+const adminNavItem = adminNavigations.map((nav) => {
   return {
     label: nav.name,
     icon: nav.icon,
@@ -19,6 +30,7 @@ const items = [
     }
   ],
   navItem,
+  ...(user.value?.role === Role.ADMIN ? [adminNavItem] : []),
   [
     {
       label: 'Sign out',
@@ -55,5 +67,3 @@ const items = [
     <UButton v-else to="/login" label="Login" color="neutral" variant="soft" />
   </div>
 </template>
-
-


### PR DESCRIPTION
Fixes #266

Add admin routing in `UserDropdown.vue` for easier use on mobile.

* Import `Role` from `@shelve/types`.
* Add `adminNavigations` by calling `getNavigation('admin')`.
* Add `adminNavItem` by mapping `adminNavigations` to `{ label, icon, to }`.
* Add `adminNavItem` to `items` array if `user.value?.role === Role.ADMIN`.
* Add `adminNavItem` to `items` array before the `Sign out` item.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HugoRCD/shelve/pull/292?shareId=df4090a8-d536-4eb2-ba9a-fe6088b98da5).