### PR TITLE
refactor: Update readme to promote local install instead of global

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The Shelve CLI serves as a command-line interface designed for the [Shelve](http
 
 ## Installation
 
-Install the package globally:
+Install the package locally:
 
 ```sh
-npm install -g @shelve/cli
+bun a -d @shelve/cli
 ```
 
 ## Configuration

--- a/apps/lp/app/pages/index.vue
+++ b/apps/lp/app/pages/index.vue
@@ -49,11 +49,11 @@ function useClipboard(text: string) {
         <div class="absolute bottom-16 z-20 flex w-full items-center justify-center [mask-image:linear-gradient(to_bottom,white,transparent)]">
           <div
             class="flex items-center justify-center gap-4 rounded-md bg-white/5 px-4 py-2 backdrop-blur-lg"
-            @click="useClipboard('npm install -g @shelve/cli')"
+            @click="useClipboard('bun a -d @shelve/cli')"
           >
             <div class="flex cursor-pointer items-center justify-center gap-2 text-sm text-neutral-300">
               <span>
-                npm install -g @shelve/cli
+                bun a -d @shelve/cli
               </span>
               <UIcon v-if="!copy" name="lucide:copy" />
               <UIcon v-else name="lucide:check" class="text-primary-400 text-lg" />

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,10 +14,10 @@ The Shelve CLI serves as a command-line interface designed for the [Shelve](http
 
 ## Installation
 
-Install the package globally:
+Install the package locally:
 
 ```sh
-npm install -g @shelve/cli
+bun a -d @shelve/cli
 ```
 
 ## Configuration


### PR DESCRIPTION
Fixes #305

Update installation instructions in README files and LP page to promote local installation instead of global.

* **packages/cli/README.md**
  - Change installation command to `bun a -d @shelve/cli` for local installation.

* **README.md**
  - Change installation command to `bun a -d @shelve/cli` for local installation.

* **apps/lp/app/pages/index.vue**
  - Update installation command to `bun a -d @shelve/cli` in the copy-to-clipboard functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HugoRCD/shelve/pull/310?shareId=550d3bae-8c6f-4fcf-8a6f-70021fbb87a1).