### PR TITLE
fix: error on pill variables item copy to clipboard

### DIFF
--- a/apps/shelve/app/components/form/Group.vue
+++ b/apps/shelve/app/components/form/Group.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import type { PropType } from 'vue'
-
 type GroupProps = {
   label?: string
   required?: boolean

--- a/apps/shelve/app/components/project/CreateVariables.vue
+++ b/apps/shelve/app/components/project/CreateVariables.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Variable } from '@shelve/types'
-import type { PropType } from 'vue'
 
 type CreateVariablesProps = {
   refresh: () => Promise<void>
@@ -32,17 +31,17 @@ const items = [
     {
       label: 'For production',
       icon: 'lucide:clipboard',
-      onSelect: () => copyEnv(variables!, 'production')
+      onSelect: () => copyEnv(variables, 'production')
     },
     {
       label: 'For preview',
       icon: 'lucide:clipboard',
-      onSelect: () => copyEnv(variables!, 'preview')
+      onSelect: () => copyEnv(variables, 'preview')
     },
     {
       label: 'For development',
       icon: 'lucide:clipboard',
-      onSelect: () => copyEnv(variables!, 'development')
+      onSelect: () => copyEnv(variables, 'development')
     }
   ],
   [
@@ -55,17 +54,17 @@ const items = [
     {
       label: 'For production',
       icon: 'lucide:download',
-      onSelect: () => downloadEnv(variables!, 'production')
+      onSelect: () => downloadEnv(variables, 'production')
     },
     {
       label: 'For preview',
       icon: 'lucide:download',
-      onSelect: () => downloadEnv(variables!, 'preview')
+      onSelect: () => downloadEnv(variables, 'preview')
     },
     {
       label: 'For development',
       icon: 'lucide:download',
-      onSelect: () => downloadEnv(variables!, 'development')
+      onSelect: () => downloadEnv(variables, 'development')
     }
   ],
 ]

--- a/apps/shelve/app/components/project/MainSection.vue
+++ b/apps/shelve/app/components/project/MainSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Project } from '@shelve/types'
-import type { PropType, Ref } from 'vue'
+import type { Ref } from 'vue'
 
 type ProjectProps = {
   project: Project

--- a/apps/shelve/app/components/project/VariableItem.vue
+++ b/apps/shelve/app/components/project/VariableItem.vue
@@ -1,28 +1,15 @@
 <script setup lang="ts">
 import type { Variable } from '@shelve/types'
-import type { PropType } from 'vue'
 
-const { refresh, variable, projectId } = defineProps({
-  refresh: {
-    type: Function,
-    required: true,
-  },
-  variables: {
-    type: Array as PropType<Variable[]>,
-  },
-  variable: {
-    type: Object as PropType<Variable>,
-    required: true
-  },
-  projectId: {
-    type: String,
-    required: true,
-  },
-  isSelected: {
-    type: Boolean,
-    required: true
-  }
-})
+type ProjectVariableProps = {
+  refresh: () => Promise<void>
+  variables: Variable[]
+  variable: Variable
+  projectId: string
+  isSelected: boolean
+}
+
+const { refresh, variable, projectId } = defineProps<ProjectVariableProps>()
 
 const {
   updateLoading,

--- a/apps/shelve/app/components/team/Member.vue
+++ b/apps/shelve/app/components/team/Member.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import type { Member } from '@shelve/types'
-import type { PropType } from 'vue'
 
-defineProps({
-  member: {
-    type: Object as PropType<Member>,
-    required: true
-  }
-})
+type TeamMemberProps = {
+  member: Member
+}
+
+defineProps<TeamMemberProps>()
 </script>
 
 <template>

--- a/apps/shelve/app/utils/env.ts
+++ b/apps/shelve/app/utils/env.ts
@@ -1,9 +1,14 @@
 import type { Variable } from '@shelve/types'
 
-export function copyEnv(variables: Variable[], env: 'production' | 'preview' | 'development') {
+export function copyEnv(variables: Variable[], env?: 'production' | 'preview' | 'development') {
   if (variables.length === 0) return
-  const envVariables = variables.filter((variable) => variable.environment.includes(env))
-  const envString = envVariables.map((variable) => `${variable.key}=${variable.value}`).join('\n')
+  if (env) {
+    const envVariables = variables.filter((variable) => variable.environment.includes(env))
+    const envString = envVariables.map((variable) => `${ variable.key }=${ variable.value }`).join('\n')
+    copyToClipboard(envString, 'Copied to clipboard')
+    return
+  }
+  const envString = variables.map((variable) => `${ variable.key }=${ variable.value }`).join('\n')
   copyToClipboard(envString, 'Copied to clipboard')
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `apps/shelve` project, focusing on refactoring components and improving utility functions. The most important changes include removing unnecessary `PropType` imports, updating the handling of the `variables` parameter, and enhancing the `copyEnv` function.

Refactoring components:

* [`apps/shelve/app/components/form/Group.vue`](diffhunk://#diff-06fce854fb5e7b178b3e6ec9dbd8f927281e4773b5aee1d0715c875bab401bf4L2-L3): Removed the unused `PropType` import.
* [`apps/shelve/app/components/project/CreateVariables.vue`](diffhunk://#diff-3f55deb2680989c1d45312b2653daaaec5e7a377ef1466c8e7c4fb8e284cecefL3): Removed the unnecessary `PropType` import and updated the `variables` parameter to remove the non-null assertion operator. [[1]](diffhunk://#diff-3f55deb2680989c1d45312b2653daaaec5e7a377ef1466c8e7c4fb8e284cecefL3) [[2]](diffhunk://#diff-3f55deb2680989c1d45312b2653daaaec5e7a377ef1466c8e7c4fb8e284cecefL35-R44) [[3]](diffhunk://#diff-3f55deb2680989c1d45312b2653daaaec5e7a377ef1466c8e7c4fb8e284cecefL58-R67)
* [`apps/shelve/app/components/project/MainSection.vue`](diffhunk://#diff-fc7f0fd54126a5807ff9a1fe11dc123f9b7b14d558c7c9cf6964c9edc29e8b42L3-R3): Removed the unused `PropType` import.
* [`apps/shelve/app/components/project/VariableItem.vue`](diffhunk://#diff-590e2dd56629677fe66f906fe4b9b7712acef315ee4d35b79cf8caeddaf071d3L3-R12): Removed the `PropType` import and refactored the component to use a type alias for props.
* [`apps/shelve/app/components/team/Member.vue`](diffhunk://#diff-04af0f0fd3157c8537612f3ada813a8bafcb390540ac5fac2810b6e007b4e29dL3-R8): Removed the `PropType` import and refactored the component to use a type alias for props.

Improving utility functions:

* [`apps/shelve/app/utils/env.ts`](diffhunk://#diff-d5eb9ccdf34625a7b541b124bacdf73370c1081244924cac54afdac1792541b9L3-R12): Enhanced the `copyEnv` function to handle cases where the `env` parameter is not provided.

resolve #312 