### PR TITLE
feat: Add a simple way to define admin users

### DIFF
--- a/apps/shelve/.env.example
+++ b/apps/shelve/.env.example
@@ -10,4 +10,4 @@ SHELVE_TOKEN=your_value
 NUXT_PUBLIC_APP_URL=your_value
 NUXT_SESSION_PASSWORD=your_value
 DATABASE_URL=your_value
-ADMIN_USERS=user@your_domain.com,user2@another_domain.com
+NUXT_PRIVATE_ADMIN_EMAILS=user@your_domain.com,user2@another_domain.com

--- a/apps/shelve/.env.example
+++ b/apps/shelve/.env.example
@@ -10,3 +10,4 @@ SHELVE_TOKEN=your_value
 NUXT_PUBLIC_APP_URL=your_value
 NUXT_SESSION_PASSWORD=your_value
 DATABASE_URL=your_value
+ADMIN_USERS=user@your_domain.com,user2@another_domain.com

--- a/apps/shelve/nuxt.config.ts
+++ b/apps/shelve/nuxt.config.ts
@@ -38,12 +38,12 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      appUrl: process.env.NUXT_PUBLIC_APP_URL || 'http://localhost:3000',
+      appUrl: '',
     },
     private: {
-      resendApiKey: process.env.NUXT_PRIVATE_RESEND_API_KEY,
-      encryptionKey: process.env.NUXT_PRIVATE_ENCRYPTION_KEY,
-      adminUsers: process.env.ADMIN_USERS,
+      resendApiKey: '',
+      encryptionKey: '',
+      adminEmails: '',
     },
   },
 

--- a/apps/shelve/nuxt.config.ts
+++ b/apps/shelve/nuxt.config.ts
@@ -43,6 +43,7 @@ export default defineNuxtConfig({
     private: {
       resendApiKey: process.env.NUXT_PRIVATE_RESEND_API_KEY,
       encryptionKey: process.env.NUXT_PRIVATE_ENCRYPTION_KEY,
+      adminUsers: process.env.ADMIN_USERS,
     },
   },
 

--- a/apps/shelve/server/services/user.service.ts
+++ b/apps/shelve/server/services/user.service.ts
@@ -1,5 +1,5 @@
 import type { CreateUserInput, UpdateUserInput, PublicUser } from '@shelve/types'
-// import { EmailService } from '~~/server/services/resend.service'
+import { Role } from '@shelve/types'
 
 export class UserService {
 
@@ -18,6 +18,9 @@ export class UserService {
 
     const username = this.generateUniqueUsername(createUserInput.username, foundUser)
 
+    const config = useRuntimeConfig()
+    const adminUsers = config.private.adminUsers?.split(',') || []
+
     const user = await prisma.user.upsert({
       where: {
         email: createUserInput.email,
@@ -28,8 +31,10 @@ export class UserService {
       create: {
         ...createUserInput,
         username,
+        role: adminUsers.includes(createUserInput.email) ? Role.ADMIN : undefined,
       }
     })
+
     /*if (user.createdAt === user.updatedAt) {
       const emailService = new EmailService()
       await emailService.sendWelcomeEmail(user.email, user.username)

--- a/apps/shelve/server/services/user.service.ts
+++ b/apps/shelve/server/services/user.service.ts
@@ -19,7 +19,7 @@ export class UserService {
     const username = this.generateUniqueUsername(createUserInput.username, foundUser)
 
     const config = useRuntimeConfig()
-    const adminUsers = config.private.adminUsers?.split(',') || []
+    const adminEmails = config.private.adminEmails?.split(',') || []
 
     const user = await prisma.user.upsert({
       where: {
@@ -31,7 +31,7 @@ export class UserService {
       create: {
         ...createUserInput,
         username,
-        role: adminUsers.includes(createUserInput.email) ? Role.ADMIN : undefined,
+        role: adminEmails.includes(createUserInput.email) ? Role.ADMIN : undefined,
       }
     })
 

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -24,6 +24,7 @@ services:
       # Optional
       - NUXT_PUBLIC_APP_URL=${NUXT_PUBLIC_APP_URL:-http://localhost:3000}
       - NUXT_PRIVATE_RESEND_API_KEY=${NUXT_PRIVATE_RESEND_API_KEY}
+      - ADMIN_USERS=${ADMIN_USERS}
     depends_on:
       shelve_redis:
         condition: service_healthy

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -24,7 +24,7 @@ services:
       # Optional
       - NUXT_PUBLIC_APP_URL=${NUXT_PUBLIC_APP_URL:-http://localhost:3000}
       - NUXT_PRIVATE_RESEND_API_KEY=${NUXT_PRIVATE_RESEND_API_KEY}
-      - ADMIN_USERS=${ADMIN_USERS}
+      - NUXT_PRIVATE_ADMIN_EMAILS=${NUXT_PRIVATE_ADMIN_EMAILS}
     depends_on:
       shelve_redis:
         condition: service_healthy

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -11,3 +11,4 @@ NUXT_PUBLIC_APP_URL=your_value
 
 # Optional
 NUXT_PRIVATE_RESEND_API_KEY=your_value
+NUXT_PRIVATE_ADMIN_EMAILS=your_value

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -22,6 +22,7 @@ services:
       - NUXT_OAUTH_GOOGLE_CLIENT_SECRET=${NUXT_OAUTH_GOOGLE_CLIENT_SECRET}
       - NUXT_PUBLIC_APP_URL=${NUXT_PUBLIC_APP_URL:-http://localhost:3000}
       - NUXT_PRIVATE_RESEND_API_KEY=${NUXT_PRIVATE_RESEND_API_KEY}
+      - ADMIN_USERS=${ADMIN_USERS}
     depends_on:
       shelve_redis:
         condition: service_healthy

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -22,7 +22,7 @@ services:
       - NUXT_OAUTH_GOOGLE_CLIENT_SECRET=${NUXT_OAUTH_GOOGLE_CLIENT_SECRET}
       - NUXT_PUBLIC_APP_URL=${NUXT_PUBLIC_APP_URL:-http://localhost:3000}
       - NUXT_PRIVATE_RESEND_API_KEY=${NUXT_PRIVATE_RESEND_API_KEY}
-      - ADMIN_USERS=${ADMIN_USERS}
+      - NUXT_PRIVATE_ADMIN_EMAILS=${NUXT_PRIVATE_ADMIN_EMAILS}
     depends_on:
       shelve_redis:
         condition: service_healthy


### PR DESCRIPTION
This pull request introduces the concept of admin emails to the `shelve` application, allowing certain users to be assigned an admin role based on their email addresses. The key changes include updates to configuration files, the user service, and Docker setup to support this new feature.

### Configuration Updates:
* Added `NUXT_PRIVATE_ADMIN_EMAILS` to the `.env.example` files for `shelve` and Docker, which will hold a comma-separated list of admin email addresses. [[1]](diffhunk://#diff-a1e0a0e9407e52a4d74cc46ed1572c4f9d104a5a69857a82c4ea23a7d223dcb6R13) [[2]](diffhunk://#diff-ec10582dde9af6c0c622084d3244b29d496260613491c430ec8958565e2f31b4R14)

### User Service Enhancements:
* Imported `Role` from `@shelve/types` in `user.service.ts` to support role assignment.
* Updated `UserService` to fetch `adminEmails` from runtime configuration and assign the `ADMIN` role to users whose emails are included in this list. [[1]](diffhunk://#diff-4165cb3675a19ea48d3ca0faa79435dd858c35474b01e2f9bf9dab6fc99ba19cR21-R23) [[2]](diffhunk://#diff-4165cb3675a19ea48d3ca0faa79435dd858c35474b01e2f9bf9dab6fc99ba19cR34-R37)

### Docker Configuration:
* Added `NUXT_PRIVATE_ADMIN_EMAILS` to the environment variables in `docker-compose.community.yml` and `docker-compose.local.yml` to ensure the admin emails are correctly passed to the application. [[1]](diffhunk://#diff-5ba60bf97d4906932bb67a1cb78545c46bef0a96d3dfb458b8ae84a993794041R27) [[2]](diffhunk://#diff-a5b09d62aa1cfc92360aacd0d2c26b94b8b21e3e96b4ac26d25b1dad53f55574R25)

### Nuxt Configuration:
* Updated `nuxt.config.ts` to include `adminEmails` in the private runtime configuration.

Fixes #302