### PR TITLE
feat: First View Transition integration

### DIFF
--- a/apps/shelve/app/components/project/MainSection.vue
+++ b/apps/shelve/app/components/project/MainSection.vue
@@ -101,11 +101,11 @@ function getProjectManager(manager: string) {
     <div v-if="!loading">
       <div class="flex items-start justify-between gap-4">
         <div class="flex items-start gap-4">
-          <UAvatar :src="project.logo" size="xl" :alt="project.name" />
+          <UAvatar :src="project.logo" size="xl" :alt="project.name" class="logo" />
           <div>
-            <h2 class="text-base font-semibold leading-7">
+            <h3 class="text-base font-semibold leading-7">
               {{ project.name }}
-            </h2>
+            </h3>
             <p class="text-sm leading-6 text-neutral-500">
               {{ project.description }}
             </p>
@@ -203,3 +203,17 @@ function getProjectManager(manager: string) {
     </UModal>
   </div>
 </template>
+
+<style scoped>
+.logo {
+  view-transition-name: project-logo;
+}
+
+h3 {
+  view-transition-name: project-name;
+}
+
+p {
+  view-transition-name: project-description;
+}
+</style>

--- a/apps/shelve/app/components/setting/ThemeToggle.vue
+++ b/apps/shelve/app/components/setting/ThemeToggle.vue
@@ -13,7 +13,7 @@ const switchTheme = () => {
   colorMode.preference = colorMode.value
 }
 
-function startViewTransition(theme) {
+const startViewTransition = (theme) => {
   if (theme === colorMode.value) return
   if (!document.startViewTransition) {
     switchTheme()
@@ -23,7 +23,16 @@ function startViewTransition(theme) {
     switchTheme()
     return
   }
-  document.startViewTransition(switchTheme)
+
+  document.documentElement.classList.add('theme-transitioning')
+
+  const transition = document.startViewTransition(() => {
+    switchTheme()
+  })
+
+  transition.finished.then(() => {
+    document.documentElement.classList.remove('theme-transitioning')
+  })
 }
 </script>
 
@@ -46,24 +55,25 @@ function startViewTransition(theme) {
 </template>
 
 <style>
-/* Dark/Light reveal effect */
-::view-transition-group(root) {
+.theme-transitioning::view-transition-group(root) {
   animation-duration: 1.5s;
 }
-::view-transition-new(root),
-::view-transition-old(root) {
+
+.theme-transitioning::view-transition-new(root),
+.theme-transitioning::view-transition-old(root) {
   mix-blend-mode: normal;
 }
 
-::view-transition-new(root) {
+.theme-transitioning::view-transition-new(root) {
   animation-name: reveal-light;
 }
 
-::view-transition-old(root),
-.dark::view-transition-old(root) {
+.theme-transitioning::view-transition-old(root),
+.dark.theme-transitioning::view-transition-old(root) {
   animation: none;
 }
-.dark::view-transition-new(root) {
+
+.dark.theme-transitioning::view-transition-new(root) {
   animation-name: reveal-dark;
 }
 
@@ -84,4 +94,5 @@ function startViewTransition(theme) {
     clip-path: polygon(130% 0, -30% 0, -15% 100%, 110% 115%);
   }
 }
+
 </style>

--- a/apps/shelve/app/pages/projects.vue
+++ b/apps/shelve/app/pages/projects.vue
@@ -9,6 +9,8 @@ const projects = useUserProjects()
 const { loading, fetchProjects } = useProjects()
 
 await fetchProjects()
+
+const active = useState('active-project')
 </script>
 
 <template>
@@ -35,19 +37,21 @@ await fetchProjects()
           :key="project.id"
           :to="`/project/${project.id}`"
         >
-          <UCard class="h-full">
+          <UCard class="h-full" @click.native="active = project.id">
             <div class="flex w-full items-start gap-4">
               <UAvatar
                 :src="project.logo"
                 :alt="project.name"
                 size="sm"
                 img-class="object-cover"
+                class="logo"
+                :class="{ active: active === project.id }"
               />
               <div class="flex flex-col gap-1">
-                <h3 class="flex flex-col text-lg font-semibold">
+                <h3 class="flex flex-col text-lg font-semibold" :class="{ active: active === project.id }">
                   {{ project.name }}
                 </h3>
-                <div class="text-xs font-normal text-neutral-500">
+                <div class="text-xs font-normal text-neutral-500" :class="{ active: active === project.id }">
                   {{ project.description }}
                 </div>
               </div>
@@ -61,3 +65,17 @@ await fetchProjects()
     </div>
   </div>
 </template>
+
+<style scoped>
+.logo.active {
+  view-transition-name: project-logo;
+}
+
+h3.active {
+  view-transition-name: project-name;
+}
+
+div.active {
+  view-transition-name: project-description;
+}
+</style>

--- a/apps/shelve/nuxt.config.ts
+++ b/apps/shelve/nuxt.config.ts
@@ -12,6 +12,10 @@ export default defineNuxtConfig({
     compatibilityVersion: 4,
   },
 
+  experimental: {
+    viewTransition: true,
+  },
+
   ssr: false,
 
   nitro: {


### PR DESCRIPTION
This pull request includes several changes to improve the user experience and functionality of the `apps/shelve` application. The most important changes focus on enhancing view transitions and adding active state management for project elements.

Enhancements to view transitions:

* [`apps/shelve/app/components/project/MainSection.vue`](diffhunk://#diff-fc7f0fd54126a5807ff9a1fe11dc123f9b7b14d558c7c9cf6964c9edc29e8b42L104-R108): Added `view-transition-name` attributes to the project logo, name, and description to enable smooth transitions. [[1]](diffhunk://#diff-fc7f0fd54126a5807ff9a1fe11dc123f9b7b14d558c7c9cf6964c9edc29e8b42L104-R108) [[2]](diffhunk://#diff-fc7f0fd54126a5807ff9a1fe11dc123f9b7b14d558c7c9cf6964c9edc29e8b42R206-R219)
* [`apps/shelve/app/components/setting/ThemeToggle.vue`](diffhunk://#diff-85b4e7965271bc4178243d55dc3a1bc35a8fcf9a2d1807d0a7180313d82be6b1L16-R16): Updated `startViewTransition` function to use a more robust approach with `document.startViewTransition` and added a `theme-transitioning` class to manage the transition state. [[1]](diffhunk://#diff-85b4e7965271bc4178243d55dc3a1bc35a8fcf9a2d1807d0a7180313d82be6b1L16-R16) [[2]](diffhunk://#diff-85b4e7965271bc4178243d55dc3a1bc35a8fcf9a2d1807d0a7180313d82be6b1L26-R35) [[3]](diffhunk://#diff-85b4e7965271bc4178243d55dc3a1bc35a8fcf9a2d1807d0a7180313d82be6b1L49-R76) [[4]](diffhunk://#diff-85b4e7965271bc4178243d55dc3a1bc35a8fcf9a2d1807d0a7180313d82be6b1R97)
* [`apps/shelve/nuxt.config.ts`](diffhunk://#diff-142308a1762da8d689c97c2b4463e8dad250aeaacba4b35f67ec020b4415b516R15-R18): Enabled the experimental `viewTransition` feature.

Active state management for projects:

* [`apps/shelve/app/pages/projects.vue`](diffhunk://#diff-489fd9205668d122af3f4f083e0c3ba8c03a6e46a8f43bda552484c1ec1fbb35R12-R13): Introduced an `active-project` state to manage the active project and added corresponding `view-transition-name` attributes to project elements. [[1]](diffhunk://#diff-489fd9205668d122af3f4f083e0c3ba8c03a6e46a8f43bda552484c1ec1fbb35R12-R13) [[2]](diffhunk://#diff-489fd9205668d122af3f4f083e0c3ba8c03a6e46a8f43bda552484c1ec1fbb35L38-R54) [[3]](diffhunk://#diff-489fd9205668d122af3f4f083e0c3ba8c03a6e46a8f43bda552484c1ec1fbb35R68-R81)

resolve #332 