### PR TITLE
enhancement: Environment view now show variable count

### DIFF
--- a/apps/shelve/app/pages/environments.vue
+++ b/apps/shelve/app/pages/environments.vue
@@ -13,6 +13,7 @@ const {
 
 const newEnv = ref('')
 const loading = ref(false)
+const ceateLoading = ref(false)
 const updateLoading = ref(false)
 
 const columns = [
@@ -21,7 +22,7 @@ const columns = [
     header: 'Name',
   },
   {
-    accessorKey: 'variableCount',
+    accessorKey: 'variablesCount',
     header: 'Variable Count',
   },
   {
@@ -33,16 +34,16 @@ const columns = [
 async function fetchEnvironments() {
   loading.value = true
   try {
-    const environments = await $fetch<Environment[]>(`/api/environments?teamId=${teamId.value}`)
-    teamEnv.value = environments
+    teamEnv.value = await $fetch<Environment[]>(`/api/environments?teamId=${ teamId.value }`)
   } catch (error) {
     console.error(error)
   }
   loading.value = false
 }
+fetchEnvironments()
 
 async function create() {
-  loading.value = true
+  ceateLoading.value = true
   try {
     if (!newEnv.value) {
       toast.error('Environment name is required')
@@ -63,7 +64,7 @@ async function create() {
   } catch (error) {
     console.error(error)
   }
-  loading.value = false
+  ceateLoading.value = false
 }
 
 async function updateEnv(env: Environment) {
@@ -120,10 +121,6 @@ function updateEnvironment(env: Environment) {
     error: 'Error updating environment',
   })
 }
-
-onMounted(() => {
-  fetchEnvironments()
-})
 </script>
 
 <template>
@@ -140,16 +137,16 @@ onMounted(() => {
         </div>
         <form class="flex items-center gap-2" @submit.prevent="createEnvironment">
           <UInput v-model="newEnv" placeholder="New environment name" required />
-          <UButton label="Create" color="primary" :loading size="sm" type="submit" />
+          <UButton label="Create" color="primary" :loading="ceateLoading" size="sm" type="submit" />
         </form>
       </div>
       <div style="--stagger: 2" data-animate class="mt-6">
-        <UTable :data="teamEnv" :columns>
+        <UTable :data="teamEnv" :columns :loading>
           <template #name-cell="{ row }">
             {{ capitalize(row.original.name) }}
           </template>
           <template #variableCount-cell="{ row }">
-            {{ row.original.variableCount }}
+            {{ row.original.variablesCount }}
           </template>
           <template #actions-cell="{ row }">
             <div class="flex gap-2">

--- a/apps/shelve/server/api/environments/index.get.ts
+++ b/apps/shelve/server/api/environments/index.get.ts
@@ -10,5 +10,7 @@ export default eventHandler(async (event) => {
 
   const resolvedTeamId = teamId || await new TeamsService().getPrivateUserTeamId(user.id)
 
-  return await new EnvironmentsService().getEnvironments(resolvedTeamId)
+  const environments = await new EnvironmentsService().getEnvironmentsWithVariableCounts(resolvedTeamId)
+
+  return environments
 })

--- a/apps/shelve/server/api/environments/index.get.ts
+++ b/apps/shelve/server/api/environments/index.get.ts
@@ -10,7 +10,5 @@ export default eventHandler(async (event) => {
 
   const resolvedTeamId = teamId || await new TeamsService().getPrivateUserTeamId(user.id)
 
-  const environments = await new EnvironmentsService().getEnvironmentsWithVariableCounts(resolvedTeamId)
-
-  return environments
+  return await new EnvironmentsService().getEnvironments(resolvedTeamId)
 })

--- a/apps/shelve/server/services/environments.ts
+++ b/apps/shelve/server/services/environments.ts
@@ -21,6 +21,23 @@ export class EnvironmentsService {
     })
   }
 
+  async getEnvironmentsWithVariableCounts(teamId: number): Promise<Environment[]> {
+    const environments = await this.getEnvironments(teamId)
+    const db = useDrizzle()
+
+    const environmentsWithCounts = await Promise.all(environments.map(async (env) => {
+      const variableCount = await db.query.variables.count({
+        where: eq(tables.variables.environmentId, env.id)
+      })
+      return {
+        ...env,
+        variableCount
+      }
+    }))
+
+    return environmentsWithCounts
+  }
+
   async updateEnvironment(input: UpdateEnvironmentInput): Promise<Environment> {
     const [environment] = await useDrizzle().update(tables.environments)
       .set({

--- a/apps/shelve/server/services/environments.ts
+++ b/apps/shelve/server/services/environments.ts
@@ -17,25 +17,13 @@ export class EnvironmentsService {
   async getEnvironments(teamId: number): Promise<Environment[]> {
     return await useDrizzle().query.environments.findMany({
       where: eq(tables.environments.teamId, teamId),
-      orderBy: [asc(tables.environments.name)]
+      orderBy: [asc(tables.environments.name)],
+      extras: {
+        variablesCount: useDrizzle()
+          .$count(tables.variableValues, eq(tables.variableValues.environmentId, tables.environments.id))
+          .as('variablesCount'),
+      },
     })
-  }
-
-  async getEnvironmentsWithVariableCounts(teamId: number): Promise<Environment[]> {
-    const environments = await this.getEnvironments(teamId)
-    const db = useDrizzle()
-
-    const environmentsWithCounts = await Promise.all(environments.map(async (env) => {
-      const variableCount = await db.query.variables.count({
-        where: eq(tables.variables.environmentId, env.id)
-      })
-      return {
-        ...env,
-        variableCount
-      }
-    }))
-
-    return environmentsWithCounts
   }
 
   async updateEnvironment(input: UpdateEnvironmentInput): Promise<Environment> {

--- a/packages/types/src/Environment.ts
+++ b/packages/types/src/Environment.ts
@@ -8,6 +8,7 @@ export type Environment = {
   id: number
   name: string
   teamId: number
+  variablesCount?: number
   createdAt: Date
   updatedAt: Date
 }


### PR DESCRIPTION
Fixes #339

Enhance the environments view to display the number of variables associated with each environment.

* Modify `apps/shelve/server/api/environments/index.get.ts` to fetch environments with variable counts.
* Update `apps/shelve/app/pages/environments.vue` to display the variable count for each environment in the table.
* Add a method in `apps/shelve/server/services/environments.ts` to get the variable count for each environment and include it in the environment data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HugoRCD/shelve/pull/340?shareId=af44f64a-1aa5-4fcb-83a9-757f571a5e1b).