### PR TITLE
feat: Download project config

### DIFF
--- a/apps/shelve/app/components/project/MainSection.vue
+++ b/apps/shelve/app/components/project/MainSection.vue
@@ -68,9 +68,9 @@ const items = [
       icon: 'lucide:download',
       onSelect: () => {
         const config = {
-          "$schema": "https://raw.githubusercontent.com/HugoRCD/shelve/main/packages/types/schema.json",
-          "project": project.value.name,
-          "slug": teamSlug
+          '$schema': 'https://raw.githubusercontent.com/HugoRCD/shelve/main/packages/types/schema.json',
+          'project': project.value.name,
+          'slug': teamSlug
         }
         const data = JSON.stringify(config, null, 2)
         const blob = new Blob([data], { type: 'application/json' })

--- a/apps/shelve/app/components/project/MainSection.vue
+++ b/apps/shelve/app/components/project/MainSection.vue
@@ -64,6 +64,24 @@ const items = [
       }
     },
     {
+      label: 'Download project config',
+      icon: 'lucide:download',
+      onSelect: () => {
+        const config = {
+          "$schema": "https://raw.githubusercontent.com/HugoRCD/shelve/main/packages/types/schema.json",
+          "project": project.value.name,
+          "slug": teamSlug
+        }
+        const data = JSON.stringify(config, null, 2)
+        const blob = new Blob([data], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `shelve.config.json`
+        a.click()
+      }
+    },
+    {
       label: 'Delete project',
       icon: 'lucide:trash',
       iconClass: 'text-red-500 dark:text-red-500',


### PR DESCRIPTION
Fixes #359

Add a button to download project config in MainSection.vue

* Add a new button labeled "Download project config" to the `items` array.
* Implement the `onSelect` function for the new button to download the project config in JSON format.
* Use the structure provided in the issue for the project config JSON.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HugoRCD/shelve/pull/381?shareId=05ca5440-b09e-457a-8c1c-038e96d271f4).