### PR TITLE
feat(app): add bot-id protection

### DIFF
--- a/apps/base/package.json
+++ b/apps/base/package.json
@@ -10,7 +10,6 @@
   },
   "packageManager": "pnpm@10.22.0",
   "devDependencies": {
-    "@nuxthub/core": "npm:@nuxthub/core-nightly@1.0.0-20251110-155642-7079e09",
     "@iconify-json/heroicons": "^1.2.3",
     "@iconify-json/lucide": "^1.2.73",
     "@iconify-json/simple-icons": "^1.2.58",
@@ -18,6 +17,7 @@
     "@nuxt/image": "^1.11.0",
     "@nuxt/scripts": "^0.13.0",
     "@nuxt/ui": "^4.1.0",
+    "@nuxthub/core": "npm:@nuxthub/core-nightly@1.0.0-20251110-155642-7079e09",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "@vueuse/core": "^14.0.0",
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@nuxtjs/mdc": "^0.18.2",
+    "botid": "^1.5.10",
     "shaders": "^2.1.9"
   }
 }

--- a/apps/shelve/app/plugins/botid.client.ts
+++ b/apps/shelve/app/plugins/botid.client.ts
@@ -1,0 +1,13 @@
+import { initBotId } from 'botid/client/core'
+
+export default defineNuxtPlugin({
+  enforce: 'pre',
+  setup() {
+    initBotId({
+      protect: [
+        { path: '/api/auth/otp/send', method: 'POST' },
+        { path: '/api/auth/otp/verify', method: 'POST' },
+      ],
+    })
+  },
+})

--- a/apps/shelve/nuxt.config.ts
+++ b/apps/shelve/nuxt.config.ts
@@ -73,5 +73,5 @@ export default defineNuxtConfig({
     format: ['webp', 'jpeg', 'jpg', 'png', 'svg']
   },
 
-  modules: ['@nuxt/ui', 'nuxt-auth-utils', '@nuxthub/core'],
+  modules: ['@nuxt/ui', 'nuxt-auth-utils', '@nuxthub/core', 'botid/nuxt'],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@nuxtjs/mdc':
         specifier: ^0.18.2
         version: 0.18.2(magicast@0.5.1)
+      botid:
+        specifier: ^1.5.10
+        version: 1.5.10(react@19.1.0)
       shaders:
         specifier: ^2.1.9
         version: 2.1.9
@@ -3933,6 +3936,17 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  botid@1.5.10:
+    resolution: {integrity: sha512-hhgty1u0CxozqTqLbTQMtYBwmWdzWZTAsBCvN7/qhkN3fM7MlXacmmcMoyc0f+vV+U6RRoLYdlo32td+PhJyew==}
+    peerDependencies:
+      next: '*'
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+      react:
+        optional: true
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -13232,6 +13246,10 @@ snapshots:
   blob-to-buffer@1.2.9: {}
 
   boolbase@1.0.0: {}
+
+  botid@1.5.10(react@19.1.0):
+    optionalDependencies:
+      react: 19.1.0
 
   brace-expansion@1.1.11:
     dependencies:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- apps (all applications)
- app (the main application)
- lp (the landing page and documentation)
- base (the base layer)
- cli (the command line interface)
- types (the type definitions)
- utils (the utility functions)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates BotId in the Nuxt app to protect OTP send/verify endpoints via a client plugin, server-side checks, and added dependency/module.
> 
> - **Auth protection (OTP)**:
>   - Add server-side BotId checks in `server/api/auth/otp/{send,verify}.post.ts`; block requests flagged as bots (403).
>   - Switch schema to `z.email(...)` for `email` validation.
> - **Client/Runtime integration**:
>   - New plugin `app/plugins/botid.client.ts` initializing BotId and protecting `POST /api/auth/otp/{send,verify}`.
>   - Register `botid/nuxt` in `apps/shelve/nuxt.config.ts` modules.
> - **Dependencies**:
>   - Add `botid` to `apps/base/package.json` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37f81a8d8e7d1a13912ddf14f18a5f48dea9aef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->