### PR TITLE
fix(cli): allow global commands without package.json

### DIFF
--- a/.changeset/global-commands-no-package-json.md
+++ b/.changeset/global-commands-no-package-json.md
@@ -1,0 +1,5 @@
+---
+"@shelve/cli": patch
+---
+
+fix: allow global commands (login, logout, me) to work without package.json

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,7 @@ import logout from './commands/logout'
 import upgrade from './commands/upgrade'
 import run from './commands/run'
 
-const pkg = await readPackageJSON()
+const pkg = await readPackageJSON().catch(() => ({ version: 'unknown' }))
 
 const main = defineCommand({
   meta: {

--- a/packages/cli/src/services/pkg.ts
+++ b/packages/cli/src/services/pkg.ts
@@ -6,7 +6,7 @@ import { FileService } from './file'
 export class PkgService {
 
   async getAllPackageJsons(workspaceDir?: string): Promise<{ path: string, dir: string, pkg: PackageJson }[]> {
-    workspaceDir = workspaceDir || await findWorkspaceDir()
+    workspaceDir = workspaceDir || await findWorkspaceDir().catch(() => process.cwd())
     const packagePaths = await glob(['**/package.json', '!**/node_modules/**'], {
       cwd: workspaceDir,
       absolute: true,
@@ -25,7 +25,7 @@ export class PkgService {
   }
 
   async isMonorepo(workspaceDir?: string): Promise<boolean> {
-    workspaceDir = workspaceDir || await findWorkspaceDir()
+    workspaceDir = workspaceDir || await findWorkspaceDir().catch(() => process.cwd())
     const packagePaths = await glob(['**/package.json', '!**/node_modules/**'], {
       cwd: workspaceDir,
       absolute: true,

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -149,9 +149,9 @@ async function checkConfig(path: string | null, isRoot = false): Promise<ShelveC
 async function getDefaultConfig(): Promise<ShelveConfig> {
   // @ts-expect-error we don't want to specify 'cwd' option
   await setupDotenv({})
-  const { name } = await readPackageJSON()
+  const { name } = await readPackageJSON().catch(() => ({ name: undefined }))
   const conf = readUser('.shelve')
-  const workspaceDir = await findWorkspaceDir()
+  const workspaceDir = await findWorkspaceDir().catch(() => process.cwd())
   const pkgService = new PkgService()
   const isMonoRepo = await pkgService.isMonorepo()
   const allPkg = await pkgService.getAllPackageJsons()


### PR DESCRIPTION
## Motivation

Use shelve as a global secrets manager - store API keys and access them from scripts in any directory. Currently `shelve login` fails outside project directories because it requires package.json.

## Problem

Global commands (`login`, `logout`, `me`) fail without package.json:
```
Error: Cannot find matching package.json in /path or parent directories
```

## Fix

Make `readPackageJSON()` and `findWorkspaceDir()` calls fail gracefully with sensible defaults. Global commands don't need project context.

## Test

```bash
cd /tmp && shelve login  # Now works
cd /tmp && shelve me     # Now works
cd /tmp && shelve logout # Now works
```

---

Related: https://github.com/onmax/claude-config/blob/master/skills/shelve/SKILL.md