### PR TITLE
feat: auto-redirect single-team users

### DIFF
--- a/apps/shelve/app/middleware/index-redirect.ts
+++ b/apps/shelve/app/middleware/index-redirect.ts
@@ -1,0 +1,9 @@
+export default defineNuxtRouteMiddleware(async (to, from) => {
+  if (to.path !== '/') return
+  if (from.path && from.path !== '/') return
+
+  const teams = await $fetch('/api/teams')
+  if (teams.length === 1) {
+    return navigateTo(`/${teams[0].slug}`)
+  }
+})

--- a/apps/shelve/app/pages/index.vue
+++ b/apps/shelve/app/pages/index.vue
@@ -3,7 +3,7 @@ import type { Team } from '@types'
 import { useLogout } from '~/composables/useLogout'
 
 definePageMeta({
-  middleware: ['auth', 'onboarding'],
+  middleware: ['auth', 'onboarding', 'index-redirect'],
 })
 
 const teams = useTeams()


### PR DESCRIPTION
## Summary
- Single-team users auto-redirect to their team on `/`
- Multi-team users stay on `/` to select team
- Removed team switcher button from navbar

## Changes
- `Navbar.vue`: removed team avatar button
- `index-redirect.ts`: fetch teams, redirect only if 1 team