### PR TITLE
feat: project switching in command palette

### DIFF
--- a/apps/shelve/app/components/CommandPalette.vue
+++ b/apps/shelve/app/components/CommandPalette.vue
@@ -267,6 +267,9 @@ function playAction(item: CommandItem, index: number) {
                           </span>
                         </div>
 
+                        <span v-if="item.suffix" class="text-xs text-muted">
+                          {{ item.suffix }}
+                        </span>
                         <UIcon
                           v-if="item.hasSubmenu"
                           name="lucide:chevron-right"

--- a/apps/shelve/app/composables/useAppCommands.ts
+++ b/apps/shelve/app/composables/useAppCommands.ts
@@ -1,5 +1,4 @@
-import type { CommandGroup, CommandItem, SubMenuState } from '@types'
-import type { Project } from '@types'
+import type { CommandGroup, CommandItem, SubMenuState, Project } from '@types'
 
 export function useAppCommands() {
   const teams = useTeams()

--- a/packages/types/src/Command.ts
+++ b/packages/types/src/Command.ts
@@ -4,6 +4,7 @@ export interface CommandItem {
   icon: string
   isAvatar?: boolean
   description?: string
+  suffix?: string
   action?: () => void | Promise<void>
   keywords?: string[]
   active?: boolean


### PR DESCRIPTION
Adds project switching to command palette. Search and navigate to any project across all teams via Cmd+K. Projects from other teams show team name as suffix.

Fetches all team projects in parallel on load, with per-team error handling to keep palette working if one API call fails. Shows all projects from all teams, hidden only if user has single project total.

https://github.com/user-attachments/assets/e1306e42-34a4-4aeb-9a91-f39ebe2e577b