### PR TITLE
feat: allow invited users to complete onboarding without creating a new team

### DIFF
--- a/apps/shelve/app/pages/onboarding.vue
+++ b/apps/shelve/app/pages/onboarding.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
+import type { Team } from '@types'
 
 definePageMeta({
   layout: 'auth',
@@ -25,7 +26,38 @@ const defaultTeamSlug = useCookie<string>('defaultTeamSlug')
 const {
   createTeam,
   selectTeam,
+  fetchTeams,
+  loading,
 } = useTeamsService()
+
+const teams = useTeams()
+const navLoading = ref(false)
+const active = ref()
+const showCreateForm = ref(false)
+
+onMounted(async () => {
+  await fetchTeams()
+})
+
+async function selectTeamAndCompleteOnboarding(team: Team) {
+  active.value = team.id
+  navLoading.value = true
+  try {
+    await $fetch('/api/user/onboarding', {
+      method: 'POST',
+      body: {
+        teamSlug: team.slug,
+      }
+    })
+    user.value!.onboarding = true
+    defaultTeamSlug.value = team.slug
+    await selectTeam(team)
+  } catch (error) {
+    console.error(error)
+    toast.error('Failed to complete onboarding')
+    navLoading.value = false
+  }
+}
 
 async function createTeamAndCompleteOnboarding(event: FormSubmitEvent<Schema>) {
   try {
@@ -91,7 +123,8 @@ async function createTeamAndCompleteOnboarding(event: FormSubmitEvent<Schema>) {
           <ScrambleText label="Welcome to Shelve" />
         </h1>
         <p class="text-muted italic">
-          Let's create your first team together
+          <span v-if="teams && teams.length > 0">Select a team or create a new one</span>
+          <span v-else>Let's create your first team together</span>
         </p>
       </div>
     </Motion>
@@ -112,7 +145,48 @@ async function createTeamAndCompleteOnboarding(event: FormSubmitEvent<Schema>) {
         delay: 0.7
       }"
     >
-      <UForm :state :schema class="space-y-2" @submit="createTeamAndCompleteOnboarding">
+      <!-- Team selector if teams exist -->
+      <div v-if="teams && teams.length > 0 && !showCreateForm" class="space-y-4">
+        <div v-if="!loading" class="flex flex-col gap-4">
+          <div
+            v-for="team in teams"
+            :key="team.id"
+            class="flex items-center justify-between gap-4 cursor-pointer bg-default p-4 rounded-lg dark:shadow-md ring-2 ring-transparent hover:ring-primary transition-colors duration-300 ease-in-out"
+            @click="selectTeamAndCompleteOnboarding(team)"
+          >
+            <div class="flex items-center gap-2">
+              <UAvatar :src="team.logo" class="size-10 logo" :class="{ active: active === team.id }" />
+              <div class="flex flex-col">
+                <span class="text-sm font-semibold team-name" :class="{ active: active === team.id }">{{ team.name }}</span>
+                <span class="text-xs text-muted">{{ team.slug }}</span>
+              </div>
+            </div>
+            <UButton size="sm" variant="soft" trailing :loading="navLoading && active === team.id">
+              Select
+            </UButton>
+          </div>
+        </div>
+        <div v-else class="flex flex-col gap-4">
+          <div v-for="i in 2" :key="i" class="flex items-center justify-between gap-4 bg-default p-4 rounded-lg dark:shadow-md">
+            <div class="flex items-center gap-2">
+              <USkeleton class="size-10 rounded-full" />
+              <div class="flex flex-col gap-2">
+                <USkeleton class="w-40 h-3" />
+                <USkeleton class="w-16 h-3" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <UButton
+          label="Create New Team"
+          variant="outline"
+          icon="lucide:circle-plus"
+          block
+          @click="showCreateForm = true"
+        />
+      </div>
+      <!-- Original Team creation form -->
+      <UForm v-else :state :schema class="space-y-2" @submit="createTeamAndCompleteOnboarding">
         <UFormField name="teamName">
           <UInput
             v-model="state.teamName"
@@ -127,6 +201,13 @@ async function createTeamAndCompleteOnboarding(event: FormSubmitEvent<Schema>) {
           block
           loading-auto
           type="submit"
+        />
+        <UButton
+          v-if="teams && teams.length > 0"
+          label="Back to Teams"
+          variant="ghost"
+          block
+          @click="showCreateForm = false"
         />
       </UForm>
     </Motion>


### PR DESCRIPTION
Additions to  /onboarding:
- reusing fetchTeams() from useTeams.ts that checks for any team memberships of the new user. 

- New team selector in frontend that renders conditionally if the user has any membership already, otherwise it renders original team creation form.

- "Create New Team" button if the user has any membership to still allow them to create a new seperate team if they want to.

- "Back to Teams" button so that if the user clicks on "Create New Team" and renders the form, they have the option to still go back without completing the creation if they dont want to.

<img width="3131" height="1249" alt="onboarding_new" src="https://github.com/user-attachments/assets/4874b96c-50cf-4d57-9a0c-1bc97a4ce149" />
<img width="1580" height="1345" alt="image" src="https://github.com/user-attachments/assets/a94dc938-cfce-460c-a5ad-9f9398f38af8" />
