### PR TITLE
fix(app): use request origin for invitation email URL instead of undefined config

### DIFF
--- a/apps/shelve/server/api/teams/[slug]/invitations/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/invitations/index.post.ts
@@ -23,7 +23,7 @@ export default eventHandler(async (event: H3Event) => {
 
   // Send invitation email
   const config = useRuntimeConfig(event)
-  const appUrl = config.public.appUrl || 'http://localhost:3000'
+  const appUrl = getRequestURL(event).origin || 'http://localhost:3000'
   const inviteUrl = `${appUrl}/invite/${invitation.token}`
 
   await new EmailService(event).sendInvitationEmail({


### PR DESCRIPTION
### 🔗 Linked issue

resolves #715 

### 📚 Description

## Fix invitation email sending localhost URL

Invitation emails were including http://localhost:3000 links instead of the actual app URL (https://app.shelve.cloud).

Root cause: The invitation endpoint used config.public.appUrl which was never defined in the runtime config, so it always fell back to 'http://localhost:3000'.

Fix: Use getRequestURL(event).origin to derive the URL from the incoming request, matching the pattern used by the OTP endpoint.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
