### PR TITLE
fix(app): align welcomeEmail props with EmailService

### DIFF
--- a/.changeset/fix-welcome-email-props.md
+++ b/.changeset/fix-welcome-email-props.md
@@ -1,0 +1,9 @@
+---
+"app": patch
+---
+
+Fix the Vue warning `[Vue warn]: Missing required prop: "name"` when sending
+the welcome email: the template declared a required `name` prop but the
+`EmailService` passes `username` and `redirectUrl`. Aligned the props with
+what the service actually sends, and wired `redirectUrl` into the call-to-
+action button (it was hardcoded to `https://app.shelve.cloud` before).

--- a/apps/shelve/server/emails/welcomeEmail.vue
+++ b/apps/shelve/server/emails/welcomeEmail.vue
@@ -17,7 +17,11 @@ import {
 } from '@vue-email/components'
 
 defineProps({
-  name: {
+  username: {
+    type: String,
+    required: true
+  },
+  redirectUrl: {
     type: String,
     required: true
   }
@@ -40,7 +44,7 @@ defineProps({
         />
       </Head>
       <Preview>
-        Welcome to Shelve, {{ name }}
+        Welcome to Shelve, {{ username }}
       </Preview>
       <Body class="m-0 p-0 font-sans" style="background-color: #010101;">
         <Container class="mx-auto my-10 max-w-[480px] px-6">
@@ -68,7 +72,7 @@ defineProps({
               class="text-sm m-0 mb-2 leading-relaxed"
               style="color: rgba(255, 255, 255, 0.6);"
             >
-              Hi <span style="color: #ffffff;">{{ name }}</span>,
+              Hi <span style="color: #ffffff;">{{ username }}</span>,
             </Text>
 
             <Text
@@ -80,7 +84,7 @@ defineProps({
 
             <!-- CTA Button -->
             <Button
-              href="https://app.shelve.cloud"
+              :href="redirectUrl"
               class="inline-block rounded-md px-5 py-2.5 text-sm font-medium no-underline"
               style="background-color: #ffffff; color: #010101;"
             >


### PR DESCRIPTION
## Summary

The welcome email template declared `name: required` but `EmailService.generateWelcomeTemplate` has always sent `username` + `redirectUrl`, which produced a `[Vue warn]: Missing required prop: \"name\"` every time a user signed up.

- Renamed the prop from `name` to `username` and added `redirectUrl`.
- Wired `redirectUrl` into the CTA button (it was hardcoded to `https://app.shelve.cloud`, ignoring whatever the caller passed in).

Pre-existing bug, no behavior change beyond removing the warning and honoring `redirectUrl`.

## Test plan

- [ ] Sign up a new user and watch dev server logs: no `[Vue warn]: Missing required prop` from `WelcomeEmail`.
- [ ] CTA in the rendered email goes to the configured app URL.