### PR TITLE
feat(app)!: hash API tokens, switch CLI auth to Bearer, add scoped tokens

### DIFF
--- a/.changeset/fix-token-alphabet.md
+++ b/.changeset/fix-token-alphabet.md
@@ -1,0 +1,13 @@
+---
+"@shelve/cli": patch
+"app": patch
+---
+
+Fix `she_…undefined…` tokens: the Crockford base32 alphabet was missing two
+symbols (only 30 chars instead of 32), so two random bits per token mapped to
+`undefined` and ended up baked into the literal token string. Switched to the
+standard 32-char Crockford alphabet (`0-9` + `A-Z` minus `I/L/O/U`).
+
+Tokens generated before this fix (with `undefined` baked in) keep working —
+the hash is deterministic against whatever string was issued — but you should
+rotate them: they're shorter than advertised in entropy and noticeably ugly.

--- a/.changeset/security-tokens-bearer-scopes.md
+++ b/.changeset/security-tokens-bearer-scopes.md
@@ -1,0 +1,24 @@
+---
+"@shelve/app": major
+"@shelve/cli": major
+"@shelve/types": major
+---
+
+Harden API token storage, switch CLI auth to `Authorization: Bearer`, and add scoped tokens.
+
+**Breaking — token format and storage**
+
+- Tokens are now generated with `crypto.randomBytes(32)` + Crockford base32 (no more `Math.random`) and stored as `sha256(token)` alongside a non-secret prefix. Plaintext is returned **only at creation** and never readable again. Existing tokens are invalidated by the migration — re-issue them after upgrading.
+- `GET /api/tokens` no longer returns plaintext token values; only `prefix`, `name`, `scopes`, `expiresAt`, `lastUsedAt`, `lastUsedIp` are exposed.
+- Lookup is now an O(1) hash query with `timingSafeEqual` instead of decrypting every token in a loop.
+
+**Breaking — CLI authentication**
+
+- The CLI sends `Authorization: Bearer <token>` instead of `Cookie: authToken=…`. The cookie path still works for one release window with `Deprecation` and `Sunset` response headers.
+
+**New — scoped tokens**
+
+- Tokens carry granular scopes: `teamIds`, `projectIds`, `environmentIds`, and `permissions: ('read' | 'write')[]`. Scopes are enforced server-side via `requireTokenScope`.
+- Tokens support an optional `expiresAt` and a CIDR `allowedCidrs` allowlist. `lastUsedAt` and `lastUsedIp` are written on each authenticated request.
+
+The token UI (`/user/tokens` and the create dialog) shows the prefix instead of the full token, displays scopes/expiry/last-used columns, and reveals the secret value only once at creation.

--- a/apps/shelve/app/components/token/Create.vue
+++ b/apps/shelve/app/components/token/Create.vue
@@ -1,47 +1,93 @@
 <script setup lang="ts">
-import type { Token } from '@types'
+import type { TokenPermission, TokenWithSecret } from '@types'
 
 const tokenName = ref('')
+const expiresIn = ref<string>('2592000')
+const permissions = ref<TokenPermission[]>(['read', 'write'])
 const loading = ref(false)
+const createdToken = ref<TokenWithSecret | null>(null)
+const popoverOpen = ref(false)
+
 const emits = defineEmits(['create'])
+
+const expiryOptions = [
+  { value: '3600', label: '1 hour' },
+  { value: '86400', label: '1 day' },
+  { value: '2592000', label: '30 days' },
+  { value: '7776000', label: '90 days' },
+  { value: '31536000', label: '1 year' },
+  { value: '0', label: 'Never (not recommended)' },
+]
+
+const permissionOptions = [
+  { value: 'read', label: 'read' },
+  { value: 'write', label: 'write' },
+]
 
 async function createToken() {
   loading.value = true
   try {
-    await $fetch<Token>('/api/tokens', {
+    const expiresInNum = expiresIn.value === '0' ? null : Number(expiresIn.value)
+    const created = await $fetch<TokenWithSecret>('/api/tokens', {
       method: 'POST',
       body: {
         name: tokenName.value,
+        expiresIn: expiresInNum,
+        scopes: { permissions: permissions.value },
       },
     })
+    createdToken.value = created
     emits('create')
     tokenName.value = ''
-    toast.success('Token created')
-  } catch (error) {
+    toast.success('Token created — copy it now, you will not see it again.')
+  } catch {
     toast.error('Failed to create token')
   }
   loading.value = false
+}
+
+function copyToken() {
+  if (!createdToken.value) return
+  navigator.clipboard.writeText(createdToken.value.token)
+  toast.success('Token copied to clipboard')
+}
+
+function dismissCreated() {
+  createdToken.value = null
+  popoverOpen.value = false
 }
 </script>
 
 <template>
   <div class="hidden items-center justify-end gap-2 sm:flex">
-    <UPopover arrow>
+    <UPopover v-model:open="popoverOpen" arrow>
       <CustomButton size="sm" label="Create token" />
       <template #content>
-        <form @submit.prevent="createToken(tokenName)">
-          <UCard>
-            <div class="flex flex-col gap-2">
-              <p class="flex gap-2 text-sm font-semibold leading-6">
-                Create a token
-              </p>
-              <div class="flex gap-2">
-                <UInput v-model="tokenName" label="Token name" placeholder="Token name" />
-                <UButton :loading label="Create" type="submit" />
-              </div>
+        <UCard v-if="!createdToken">
+          <form class="flex flex-col gap-3" @submit.prevent="createToken()">
+            <p class="text-sm font-semibold leading-6">
+              Create a token
+            </p>
+            <UInput v-model="tokenName" label="Token name" placeholder="My CI token" />
+            <USelect v-model="expiresIn" :items="expiryOptions" placeholder="Expiry" />
+            <UCheckboxGroup v-model="permissions" :items="permissionOptions" orientation="horizontal" />
+            <UButton :loading label="Create" type="submit" />
+          </form>
+        </UCard>
+        <UCard v-else>
+          <div class="flex flex-col gap-3">
+            <p class="text-sm font-semibold leading-6">
+              Save this token — you will not see it again
+            </p>
+            <div class="flex items-center gap-2 rounded-md border border-default bg-muted/40 p-2 font-mono text-xs break-all">
+              {{ createdToken.token }}
             </div>
-          </UCard>
-        </form>
+            <div class="flex justify-end gap-2">
+              <UButton variant="ghost" label="Done" @click="dismissCreated" />
+              <UButton icon="lucide:copy" label="Copy" @click="copyToken" />
+            </div>
+          </div>
+        </UCard>
       </template>
     </UPopover>
   </div>

--- a/apps/shelve/app/components/token/Toggle.vue
+++ b/apps/shelve/app/components/token/Toggle.vue
@@ -1,35 +1,26 @@
 <script setup lang="ts">
-const { token } = defineProps<{
-  token: string
+const { prefix } = defineProps<{
+  prefix: string
 }>()
 
-const visible = ref(false)
-
 const copy = () => {
-  navigator.clipboard.writeText(token)
-  toast.success('Token copied to clipboard')
+  navigator.clipboard.writeText(prefix)
+  toast.info('Only the prefix is shown for security. Full token is only revealed at creation.')
 }
 </script>
 
 <template>
   <div class="flex select-none items-center gap-2">
-    <div class="cursor-pointer text-sm text-muted" @click="copy">
-      **********
-    </div>
-    <UPopover>
+    <span class="text-sm font-mono text-muted">
+      {{ prefix }}…
+    </span>
+    <UTooltip text="Copy prefix">
       <UButton
-        icon="lucide:eye"
+        icon="lucide:copy"
         size="sm"
         variant="ghost"
-        @click="visible = !visible"
+        @click="copy"
       />
-      <template #content>
-        <UCard :ui="{ body: 'px-2 sm:px-2 py-1 sm:py-1' }" class="cursor-pointer hover:bg-muted" @click="copy">
-          <span class="text-sm font-mono">
-            {{ token.slice(0, 4) }}...{{ token.slice(-4) }}
-          </span>
-        </UCard>
-      </template>
-    </UPopover>
+    </UTooltip>
   </div>
 </template>

--- a/apps/shelve/app/pages/user/tokens.vue
+++ b/apps/shelve/app/pages/user/tokens.vue
@@ -9,16 +9,24 @@ const columns: TableColumn<Token>[] = [
     header: 'Name',
   },
   {
-    accessorKey: 'token',
-    header: 'Token',
+    accessorKey: 'prefix',
+    header: 'Prefix',
+  },
+  {
+    accessorKey: 'scopes',
+    header: 'Scopes',
   },
   {
     accessorKey: 'createdAt',
     header: 'Created',
   },
   {
-    accessorKey: 'updatedAt',
+    accessorKey: 'lastUsedAt',
     header: 'Last Used',
+  },
+  {
+    accessorKey: 'expiresAt',
+    header: 'Expires',
   },
   {
     accessorKey: 'actions',
@@ -29,21 +37,12 @@ const columns: TableColumn<Token>[] = [
 const items = (row: Token) => [
   [
     {
-      label: 'Copy Token',
-      icon: 'lucide:copy',
-      onSelect: () => {
-        copyToClipboard(row.token, 'Token copied to clipboard')
-      },
-    }
-  ],
-  [
-    {
       label: 'Delete',
       icon: 'lucide:trash',
       onSelect: () => {
         modal.open({
           title: 'Are you sure?',
-          description: `You are about to delete ${row.name} token which is currently ${isTokenActive(row.updatedAt) ? 'active' : 'inactive'}, this action cannot be undone.`,
+          description: `You are about to delete ${row.name} token which is currently ${isTokenActive(row.lastUsedAt) ? 'active' : 'inactive'}, this action cannot be undone.`,
           danger: true,
           onSuccess() {
             toast.promise(deleteToken(row), {
@@ -89,10 +88,11 @@ async function deleteToken(token: Token) {
   await fetchTokens()
 }
 
-function isTokenActive(value: string) {
-  const updatedAt = new Date(value)
+function isTokenActive(value: string | Date | null) {
+  if (!value) return false
+  const lastUsedAt = new Date(value)
   const oneWeekAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7)
-  return updatedAt > oneWeekAgo
+  return lastUsedAt > oneWeekAgo
 }
 
 fetchTokens()
@@ -119,22 +119,48 @@ useSeoMeta({
         td: 'border-b border-default'
       }"
     >
-      <template #token-cell="{ row }">
-        <TokenToggle :token="row.original.token" />
+      <template #prefix-cell="{ row }">
+        <TokenToggle :prefix="row.original.prefix" />
+      </template>
+      <template #scopes-cell="{ row }">
+        <div class="flex flex-wrap gap-1">
+          <UBadge
+            v-for="permission in row.original.scopes.permissions"
+            :key="permission"
+            size="sm"
+            :color="permission === 'write' ? 'warning' : 'neutral'"
+            variant="subtle"
+          >
+            {{ permission }}
+          </UBadge>
+          <UBadge
+            v-if="row.original.scopes.teamIds?.length || row.original.scopes.projectIds?.length || row.original.scopes.environmentIds?.length"
+            size="sm"
+            color="info"
+            variant="subtle"
+          >
+            scoped
+          </UBadge>
+        </div>
       </template>
       <template #createdAt-cell="{ row }">
         <DatePopover :date="row.original.createdAt" label="Created At" />
       </template>
-      <template #updatedAt-cell="{ row }">
+      <template #lastUsedAt-cell="{ row }">
         <span class="flex items-center gap-1">
-          <DatePopover :date="row.original.updatedAt" label="Last Used" />
-          <UTooltip v-if="!isTokenActive( row.original.updatedAt)" text="Token seems to be inactive">
+          <DatePopover v-if="row.original.lastUsedAt" :date="row.original.lastUsedAt" label="Last Used" />
+          <span v-else class="text-sm text-muted">never</span>
+          <UTooltip v-if="!isTokenActive(row.original.lastUsedAt)" text="Token seems to be inactive">
             <UIcon name="heroicons-outline:clock" class="size-4 text-red-600" />
           </UTooltip>
           <UTooltip v-else text="Token is active">
             <UIcon name="heroicons-outline:clock" class="size-4 text-muted" />
           </UTooltip>
         </span>
+      </template>
+      <template #expiresAt-cell="{ row }">
+        <DatePopover v-if="row.original.expiresAt" :date="row.original.expiresAt" label="Expires" />
+        <span v-else class="text-sm text-muted">never</span>
       </template>
       <template #actions-cell="{ row }">
         <UDropdownMenu :items="items(row.original)">

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/env/[envId].get.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/env/[envId].get.ts
@@ -12,6 +12,13 @@ export default eventHandler(async (event) => {
     }).int().positive(),
   }).parse)
 
+  await requireTokenScope(event, {
+    teamId: team.id,
+    projectId,
+    environmentId: envId,
+    permission: 'read',
+  })
+
   const variablesService = new VariablesService(event)
 
   variablesService.incrementStatAsync(team.id, 'pull')

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.post.ts
@@ -24,6 +24,15 @@ export default eventHandler(async (event) => {
   const body = await readValidatedBody(event, createVariablesSchema.parse)
   const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
 
+  for (const environmentId of body.environmentIds) {
+    await requireTokenScope(event, {
+      teamId: team.id,
+      projectId,
+      environmentId,
+      permission: 'write',
+    })
+  }
+
   const variablesService = new VariablesService(event)
   await variablesService.createVariables(event, {
     projectId,
@@ -38,6 +47,7 @@ export default eventHandler(async (event) => {
   })
 
   variablesService.incrementStatAsync(team.id, 'push')
+
   return {
     statusCode: 201,
     message: 'Variables created successfully',

--- a/apps/shelve/server/api/tokens/[id].delete.ts
+++ b/apps/shelve/server/api/tokens/[id].delete.ts
@@ -13,5 +13,6 @@ export default defineEventHandler(async (event) => {
     .returning()
 
   if (!deletedToken) throw createError({ statusCode: 404, message: `Token not found with id ${id}` })
+
   return deletedToken
 })

--- a/apps/shelve/server/api/tokens/index.get.ts
+++ b/apps/shelve/server/api/tokens/index.get.ts
@@ -1,17 +1,23 @@
 import type { Token } from '@types'
 
-export default defineEventHandler(async (event) => {
-  const { encryptionKey } = useRuntimeConfig(event).private
-
+export default defineEventHandler(async (event): Promise<Token[]> => {
   const { user } = await requireUserSession(event)
 
-  const tokens = await db.query.tokens.findMany({
+  return db.query.tokens.findMany({
     where: eq(schema.tokens.userId, user.id),
-    orderBy: (tokens, { desc }) => [desc(tokens.createdAt)]
+    orderBy: (tokens, { desc }) => [desc(tokens.createdAt)],
+    columns: {
+      id: true,
+      name: true,
+      prefix: true,
+      scopes: true,
+      allowedCidrs: true,
+      expiresAt: true,
+      lastUsedAt: true,
+      lastUsedIp: true,
+      createdAt: true,
+      updatedAt: true,
+      userId: true,
+    },
   })
-
-  return Promise.all(tokens.map(async (token): Promise<Token> => ({
-    ...token,
-    token: await unseal(token.token, encryptionKey) as string
-  })))
 })

--- a/apps/shelve/server/api/tokens/index.post.ts
+++ b/apps/shelve/server/api/tokens/index.post.ts
@@ -1,41 +1,48 @@
 import { z } from 'zod'
+import type { TokenWithSecret } from '@types'
 
-export default defineEventHandler(async (event) => {
-  const { name } = await readValidatedBody(event, z.object({
-    name: z.string({
-      error: 'Cannot create token without name',
-    }).min(3).max(50).trim(),
-  }).parse)
+const cidrSchema = z.string().regex(
+  /^(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}\/(?:3[0-2]|[12]?\d))$|^(?:[A-Fa-f0-9:]+)\/(?:12[0-8]|1[01]\d|[1-9]?\d)$/,
+  'Invalid CIDR notation'
+)
+
+const scopesSchema = z.object({
+  teamIds: z.array(z.number().int().positive()).optional(),
+  projectIds: z.array(z.number().int().positive()).optional(),
+  environmentIds: z.array(z.number().int().positive()).optional(),
+  permissions: z.array(z.enum(['read', 'write'])).min(1),
+}).optional()
+
+const bodySchema = z.object({
+  name: z.string({ error: 'Cannot create token without name' }).min(3).max(25).trim(),
+  scopes: scopesSchema,
+  expiresIn: z.number().int().positive().nullable().optional(),
+  allowedCidrs: z.array(cidrSchema).optional(),
+})
+
+export default defineEventHandler(async (event): Promise<TokenWithSecret> => {
+  const { name, scopes, expiresIn, allowedCidrs } = await readValidatedBody(event, bodySchema.parse)
   const { user } = await requireUserSession(event)
-  const { encryptionKey } = useRuntimeConfig(event).private
 
-  const createdToken = generateUserToken(user.id)
-  const encryptedToken = await seal(createdToken, encryptionKey)
+  const { token, prefix, hash } = generateToken()
+  const expiresAt = expiresIn ? new Date(Date.now() + expiresIn * 1000) : null
 
-  const [token] = await db.insert(schema.tokens)
+  const [created] = await db.insert(schema.tokens)
     .values({
-      token: encryptedToken,
+      hash,
+      prefix,
+      name,
       userId: user.id,
-      name
+      scopes: scopes ?? { permissions: ['read', 'write'] },
+      allowedCidrs: allowedCidrs ?? [],
+      expiresAt,
     })
     .returning()
 
-  return token
-})
+  if (!created) throw createError({ statusCode: 500, statusMessage: 'Failed to create token' })
 
-function generateUserToken(userId: number): string {
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-  let token = ''
-  const userIdHash = calculateUserIdHash(userId)
-
-  for (let i = 0; i < TOKEN_LENGTH; i++) {
-    const randomIndex = (Math.floor(Math.random() * characters.length) + userIdHash) % characters.length
-    token += characters.charAt(randomIndex)
+  return {
+    ...created,
+    token,
   }
-
-  return `${TOKEN_PREFIX}${userId}_${token}`
-}
-
-function calculateUserIdHash(userId: number): number {
-  return Array.from(String(userId)).reduce((acc, char) => acc + char.charCodeAt(0), 0)
-}
+})

--- a/apps/shelve/server/db/migrations/postgresql/0004_tokens_hash.sql
+++ b/apps/shelve/server/db/migrations/postgresql/0004_tokens_hash.sql
@@ -1,0 +1,34 @@
+-- Breaking change (Shelve v5):
+-- Tokens were previously stored as reversible iron-webcrypto seals and
+-- generated using Math.random(), which is cryptographically broken.
+-- We rotate to: sha256(token) for storage, randomBytes(32) for generation,
+-- per-token scopes, expiry, IP allowlist, and last-used metadata.
+--
+-- All pre-v5 tokens MUST be revoked because they cannot be migrated:
+--   * we never stored their hash,
+--   * we want to invalidate any leaked Math.random-derived tokens.
+TRUNCATE TABLE "tokens" RESTART IDENTITY CASCADE;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "tokens_token_idx";
+--> statement-breakpoint
+ALTER TABLE "tokens" DROP COLUMN IF EXISTS "token";
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD COLUMN "hash" varchar(64) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD COLUMN "prefix" varchar(16) NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD COLUMN "scopes" jsonb NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD COLUMN "allowedCidrs" jsonb DEFAULT '[]'::jsonb NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD COLUMN "expiresAt" timestamp;
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD COLUMN "lastUsedAt" timestamp;
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD COLUMN "lastUsedIp" varchar(45);
+--> statement-breakpoint
+ALTER TABLE "tokens" ADD CONSTRAINT "tokens_hash_unique" UNIQUE("hash");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "tokens_hash_idx" ON "tokens" USING btree ("hash");
+--> statement-breakpoint
+CREATE INDEX "tokens_prefix_idx" ON "tokens" USING btree ("prefix");

--- a/apps/shelve/server/db/migrations/postgresql/meta/0004_snapshot.json
+++ b/apps/shelve/server/db/migrations/postgresql/meta/0004_snapshot.json
@@ -1,0 +1,1621 @@
+{
+  "id": "8a1f2c5e-7b3d-4a6e-9c2f-0e1d2c3b4a5f",
+  "prevId": "63fe565e-402f-460b-a8bd-e24ec5c754f3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.environments": {
+      "name": "environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "environments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environments_team_name_idx": {
+          "name": "environments_team_name_idx",
+          "columns": [
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_team_idx": {
+          "name": "environments_team_idx",
+          "columns": [
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environments_teamId_teams_id_fk": {
+          "name": "environments_teamId_teams_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app": {
+      "name": "github_app",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "github_app_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "installationId": {
+          "name": "installationId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isOrganisation": {
+          "name": "isOrganisation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_app_userId_users_id_fk": {
+          "name": "github_app_userId_users_id_fk",
+          "tableFrom": "github_app",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "invitations_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invitedById": {
+          "name": "invitedById",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_token_idx": {
+          "name": "invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_team_idx": {
+          "name": "invitations_email_team_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_team_idx": {
+          "name": "invitations_team_idx",
+          "columns": [
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_teamId_teams_id_fk": {
+          "name": "invitations_teamId_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_invitedById_users_id_fk": {
+          "name": "invitations_invitedById_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "members_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_user_team_idx": {
+          "name": "members_user_team_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_role_idx": {
+          "name": "members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_team_role_idx": {
+          "name": "members_team_role_idx",
+          "columns": [
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_userId_users_id_fk": {
+          "name": "members_userId_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_teamId_teams_id_fk": {
+          "name": "members_teamId_teams_id_fk",
+          "tableFrom": "members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "projects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "projectManager": {
+          "name": "projectManager",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "variablePrefix": {
+          "name": "variablePrefix",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://github.com/HugoRCD/shelve/blob/main/assets/default.webp?raw=true'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_team_name_idx": {
+          "name": "projects_team_name_idx",
+          "columns": [
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_team_idx": {
+          "name": "projects_team_idx",
+          "columns": [
+            {
+              "expression": "teamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_teamId_teams_id_fk": {
+          "name": "projects_teamId_teams_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_stats": {
+      "name": "team_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "team_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_count": {
+          "name": "push_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_count": {
+          "name": "pull_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_stats_id_idx": {
+          "name": "team_stats_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_stats_teamId_teams_id_fk": {
+          "name": "team_stats_teamId_teams_id_fk",
+          "tableFrom": "team_stats",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "teamId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_stats_teamId_unique": {
+          "name": "team_stats_teamId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "teamId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "teams_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://github.com/HugoRCD/shelve/blob/main/assets/default.webp?raw=true'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "tokens_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowedCidrs": {
+          "name": "allowedCidrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUsedIp": {
+          "name": "lastUsedIp",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tokens_hash_idx": {
+          "name": "tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tokens_user_idx": {
+          "name": "tokens_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tokens_prefix_idx": {
+          "name": "tokens_prefix_idx",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tokens_userId_users_id_fk": {
+          "name": "tokens_userId_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_hash_unique": {
+          "name": "tokens_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://i.imgur.com/6VBx3io.png'"
+        },
+        "role": {
+          "name": "role",
+          "type": "roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "authType": {
+          "name": "authType",
+          "type": "auth_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding": {
+          "name": "onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cliInstalled": {
+          "name": "cliInstalled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "otpCode": {
+          "name": "otpCode",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "otpToken": {
+          "name": "otpToken",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "otpExpiresAt": {
+          "name": "otpExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "otpAttempts": {
+          "name": "otpAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "otpLastRequestAt": {
+          "name": "otpLastRequestAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variable_groups": {
+      "name": "variable_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "variable_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "variable_groups_project_name_idx": {
+          "name": "variable_groups_project_name_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variable_groups_project_idx": {
+          "name": "variable_groups_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variable_groups_projectId_projects_id_fk": {
+          "name": "variable_groups_projectId_projects_id_fk",
+          "tableFrom": "variable_groups",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variable_values": {
+      "name": "variable_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "variable_values_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "variableId": {
+          "name": "variableId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(4000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "variable_values_variable_env_idx": {
+          "name": "variable_values_variable_env_idx",
+          "columns": [
+            {
+              "expression": "variableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variable_values_env_idx": {
+          "name": "variable_values_env_idx",
+          "columns": [
+            {
+              "expression": "environmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variable_values_variableId_variables_id_fk": {
+          "name": "variable_values_variableId_variables_id_fk",
+          "tableFrom": "variable_values",
+          "tableTo": "variables",
+          "columnsFrom": [
+            "variableId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variable_values_environmentId_environments_id_fk": {
+          "name": "variable_values_environmentId_environments_id_fk",
+          "tableFrom": "variable_values",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "variables_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "variables_project_key_idx": {
+          "name": "variables_project_key_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variables_key_idx": {
+          "name": "variables_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variables_project_idx": {
+          "name": "variables_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variables_group_idx": {
+          "name": "variables_group_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variables_projectId_projects_id_fk": {
+          "name": "variables_projectId_projects_id_fk",
+          "tableFrom": "variables",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variables_groupId_variable_groups_id_fk": {
+          "name": "variables_groupId_variable_groups_id_fk",
+          "tableFrom": "variables",
+          "tableTo": "variable_groups",
+          "columnsFrom": [
+            "groupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_types": {
+      "name": "auth_types",
+      "schema": "public",
+      "values": [
+        "github",
+        "google",
+        "email"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "expired"
+      ]
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.team_role": {
+      "name": "team_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/shelve/server/db/migrations/postgresql/meta/_journal.json
+++ b/apps/shelve/server/db/migrations/postgresql/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776109866917,
       "tag": "0003_polite_madripoor",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782700000000,
+      "tag": "0004_tokens_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/shelve/server/db/schema.ts
+++ b/apps/shelve/server/db/schema.ts
@@ -1,6 +1,7 @@
-import { boolean, pgEnum, pgTable, varchar, index, uniqueIndex, bigint, integer, timestamp } from 'drizzle-orm/pg-core'
+import { boolean, pgEnum, pgTable, varchar, index, uniqueIndex, bigint, integer, timestamp, jsonb } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 import { TeamRole, Role, AuthType, InvitationStatus } from '../../../../packages/types'
+import type { TokenScopes } from '../../../../packages/types'
 
 const timestamps = {
   updatedAt: timestamp().notNull().$onUpdate(() => new Date()),
@@ -154,13 +155,20 @@ export const variableValues = pgTable('variable_values', {
 
 export const tokens = pgTable('tokens', {
   id: bigint({ mode: 'number' }).primaryKey().generatedByDefaultAsIdentity(),
-  token: varchar({ length: 800 }).unique().notNull(),
+  hash: varchar({ length: 64 }).unique().notNull(),
+  prefix: varchar({ length: 16 }).notNull(),
   name: varchar({ length: 25 }).notNull(),
   userId: bigint({ mode: 'number' }).references(() => users.id, { onDelete: 'cascade' }).notNull(),
+  scopes: jsonb().$type<TokenScopes>().notNull(),
+  allowedCidrs: jsonb().$type<string[]>().default([]).notNull(),
+  expiresAt: timestamp(),
+  lastUsedAt: timestamp(),
+  lastUsedIp: varchar({ length: 45 }),
   ...timestamps,
 }, (table) => [
-  uniqueIndex('tokens_token_idx').on(table.token),
-  index('tokens_user_idx').on(table.userId)
+  uniqueIndex('tokens_hash_idx').on(table.hash),
+  index('tokens_user_idx').on(table.userId),
+  index('tokens_prefix_idx').on(table.prefix),
 ])
 
 export const environments = pgTable('environments', {

--- a/apps/shelve/server/middleware/2.auth.ts
+++ b/apps/shelve/server/middleware/2.auth.ts
@@ -1,24 +1,41 @@
 export default defineEventHandler(async (event) => {
   if (!event.path?.startsWith('/api')) return
-
   if (event.path?.startsWith('/api/auth')) return
 
-  // Web login
   const session = await getUserSession(event)
   if (session.user) return
 
-  // CLI auth token
-  const authToken = getCookie(event, 'authToken')
-  if (!authToken) return
+  const authHeader = getRequestHeader(event, 'authorization')
+  let bearer: string | undefined
+  if (authHeader?.toLowerCase().startsWith('bearer ')) {
+    bearer = authHeader.slice(7).trim()
+  }
+
+  let legacyCookie = false
+  if (!bearer) {
+    const cookieToken = getCookie(event, 'authToken')
+    if (cookieToken) {
+      bearer = cookieToken
+      legacyCookie = true
+    }
+  }
+
+  if (!bearer) return
 
   try {
-    const user = await getUserByAuthToken(authToken, event)
+    const { user, scopes } = await authenticateToken(bearer, event)
     await setUserSession(event, {
       user,
+      tokenScopes: scopes,
       loggedInAt: new Date(),
     })
+    if (legacyCookie) {
+      setResponseHeader(event, 'Deprecation', 'true')
+      setResponseHeader(event, 'Sunset', 'Wed, 01 Jul 2026 00:00:00 GMT')
+      setResponseHeader(event, 'Link', '</docs/cli/auth>; rel="deprecation"')
+    }
   } catch {
-    // Token invalid, continue without session
-    // The route handler will throw 401 if auth is required
+    // Token invalid, continue without session.
+    // The route handler will throw 401 if auth is required.
   }
 })

--- a/apps/shelve/server/services/user.ts
+++ b/apps/shelve/server/services/user.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import type { CreateUserInput, Token, User } from '@types'
+import type { CreateUserInput, TokenScopes, User } from '@types'
 import { AuthType, Role } from '@types'
 
 async function syncUserRole(user: User, event: H3Event): Promise<User> {
@@ -101,32 +101,68 @@ function generateUniqueUsername(username: string): string {
   return `${username}_#${Math.floor(Math.random() * 1000)}`
 }
 
-export async function getUserByAuthToken(authToken: string, event: H3Event): Promise<User> {
-  const { encryptionKey } = useRuntimeConfig(event).private
-  const userId = +authToken.split('_')[1] // Extract the user ID from the token
-  const userTokens = await db.query.tokens.findMany({
-    where: eq(schema.tokens.userId, userId)
-  })
-  if (!userTokens.length) throw createError({ statusCode: 401, statusMessage: 'User not found (invalid token)' })
-
-  let foundToken: Token | undefined
-
-  for (const token of userTokens) {
-    const decryptedToken = await unseal(token.token, encryptionKey)
-    if (decryptedToken === authToken) foundToken = token
+export async function authenticateToken(
+  rawToken: string,
+  event: H3Event
+): Promise<{ user: User; scopes: TokenScopes }> {
+  if (!rawToken || !rawToken.startsWith('she_')) {
+    throw createError({ statusCode: 401, statusMessage: 'Invalid token' })
   }
 
-  if (!foundToken) throw createError({ statusCode: 401, statusMessage: 'Invalid token' })
+  const hash = hashToken(rawToken)
+  const token = await db.query.tokens.findFirst({
+    where: eq(schema.tokens.hash, hash),
+  })
+  if (!token) throw createError({ statusCode: 401, statusMessage: 'Invalid token' })
+
+  if (token.expiresAt && token.expiresAt.getTime() < Date.now()) {
+    throw createError({ statusCode: 401, statusMessage: 'Token expired' })
+  }
+
+  const ip = getRequestIP(event, { xForwardedFor: true }) ?? null
+  if (token.allowedCidrs.length > 0) {
+    if (!ip || !ip.length) {
+      throw createError({ statusCode: 401, statusMessage: 'Token IP allowlist enforced' })
+    }
+    if (!token.allowedCidrs.some((cidr) => isIpInCidr(ip, cidr))) {
+      throw createError({ statusCode: 403, statusMessage: 'IP not allowed for this token' })
+    }
+  }
 
   const user = await db.query.users.findFirst({
-    where: eq(schema.users.id, userId)
+    where: eq(schema.users.id, token.userId),
   })
-  if (!user) throw createError({ statusCode: 400, statusMessage: 'User not found (invalid token)' })
+  if (!user) throw createError({ statusCode: 401, statusMessage: 'User not found' })
 
   await db.update(schema.tokens)
-    .set({
-      updatedAt: new Date()
-    })
-    .where(eq(schema.tokens.id, foundToken.id))
-  return user
+    .set({ lastUsedAt: new Date(), lastUsedIp: ip })
+    .where(eq(schema.tokens.id, token.id))
+
+  return { user, scopes: token.scopes }
+}
+
+function isIpInCidr(ip: string, cidr: string): boolean {
+  const [range, bitsRaw] = cidr.split('/')
+  if (!range || !bitsRaw) return false
+  const bits = parseInt(bitsRaw, 10)
+  if (Number.isNaN(bits)) return false
+
+  if (ip.includes(':') !== range.includes(':')) return false
+
+  if (!ip.includes(':')) {
+    const ipNum = ipv4ToNumber(ip)
+    const rangeNum = ipv4ToNumber(range)
+    if (ipNum === null || rangeNum === null) return false
+    if (bits === 0) return true
+    const mask = (~0 << (32 - bits)) >>> 0
+    return (ipNum & mask) === (rangeNum & mask)
+  }
+
+  return false
+}
+
+function ipv4ToNumber(ip: string): number | null {
+  const parts = ip.split('.').map(Number)
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return null
+  return ((parts[0]! << 24) | (parts[1]! << 16) | (parts[2]! << 8) | parts[3]!) >>> 0
 }

--- a/apps/shelve/server/utils/auth.ts
+++ b/apps/shelve/server/utils/auth.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import type { Member, Team, User } from '@types'
+import type { Member, Team, TokenPermission, TokenScopes, User } from '@types'
 import { Role, TeamRole } from '@types'
 import { z } from 'zod'
 import { validateTeamAccess, validateTeamRole } from './validateAccess'
@@ -60,4 +60,45 @@ export async function requireUserTeam(
 export async function getTeamSlugFromEvent(event: H3Event): Promise<string> {
   const { slug } = await getValidatedRouterParams(event, teamSlugSchema.parse)
   return slug
+}
+
+/**
+ * Returns the token scopes attached to the current session, or null when
+ * authenticated via web (browser cookie session = full access for the user).
+ */
+export async function getTokenScopes(event: H3Event): Promise<TokenScopes | null> {
+  const session = await getUserSession(event)
+  return (session as { tokenScopes?: TokenScopes }).tokenScopes ?? null
+}
+
+/**
+ * Enforce a token's scopes against the resource being accessed.
+ * No-op when the request is authenticated via web session.
+ *
+ * Throws 403 if:
+ * - The required permission (`read`/`write`) is not granted.
+ * - The token is restricted to specific teams/projects/envs and the resource is not in scope.
+ */
+export async function requireTokenScope(
+  event: H3Event,
+  resource: { teamId?: number; projectId?: number; environmentId?: number; permission: TokenPermission }
+): Promise<void> {
+  const scopes = await getTokenScopes(event)
+  if (!scopes) return
+
+  if (!scopes.permissions.includes(resource.permission)) {
+    throw createError({ statusCode: 403, statusMessage: `Token missing '${resource.permission}' permission` })
+  }
+
+  if (scopes.teamIds?.length && resource.teamId !== undefined && !scopes.teamIds.includes(resource.teamId)) {
+    throw createError({ statusCode: 403, statusMessage: 'Token not authorized for this team' })
+  }
+
+  if (scopes.projectIds?.length && resource.projectId !== undefined && !scopes.projectIds.includes(resource.projectId)) {
+    throw createError({ statusCode: 403, statusMessage: 'Token not authorized for this project' })
+  }
+
+  if (scopes.environmentIds?.length && resource.environmentId !== undefined && !scopes.environmentIds.includes(resource.environmentId)) {
+    throw createError({ statusCode: 403, statusMessage: 'Token not authorized for this environment' })
+  }
 }

--- a/apps/shelve/server/utils/constants.ts
+++ b/apps/shelve/server/utils/constants.ts
@@ -1,2 +1,2 @@
 export const TOKEN_PREFIX = 'she_'
-export const TOKEN_LENGTH = 25
+export const TOKEN_PREFIX_DISPLAY_LENGTH = 12

--- a/apps/shelve/server/utils/tokens.ts
+++ b/apps/shelve/server/utils/tokens.ts
@@ -1,0 +1,43 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import { TOKEN_PREFIX, TOKEN_PREFIX_DISPLAY_LENGTH } from './constants'
+
+const CROCKFORD_ALPHABET = 'ABCDEFGHJKMNPQRSTVWXYZ23456789'
+
+function base32Encode(buf: Buffer): string {
+  let bits = 0
+  let value = 0
+  let out = ''
+  for (const byte of buf) {
+    value = (value << 8) | byte
+    bits += 8
+    while (bits >= 5) {
+      bits -= 5
+      out += CROCKFORD_ALPHABET[(value >>> bits) & 31]
+    }
+  }
+  if (bits > 0) out += CROCKFORD_ALPHABET[(value << (5 - bits)) & 31]
+  return out
+}
+
+export function generateToken(): { token: string; prefix: string; hash: string } {
+  const body = base32Encode(randomBytes(32))
+  const token = `${TOKEN_PREFIX}${body}`
+  return {
+    token,
+    prefix: token.slice(0, TOKEN_PREFIX_DISPLAY_LENGTH),
+    hash: hashToken(token),
+  }
+}
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+export function safeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'))
+  } catch {
+    return false
+  }
+}

--- a/apps/shelve/server/utils/tokens.ts
+++ b/apps/shelve/server/utils/tokens.ts
@@ -1,7 +1,10 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { TOKEN_PREFIX, TOKEN_PREFIX_DISPLAY_LENGTH } from './constants'
 
-const CROCKFORD_ALPHABET = 'ABCDEFGHJKMNPQRSTVWXYZ23456789'
+// Standard Crockford base32: 32 chars = 0-9 + A-Z minus I, L, O, U.
+// Must contain exactly 32 symbols, otherwise indices 30/31 return undefined
+// and the token ends up with the literal string "undefined" inside it.
+const CROCKFORD_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
 
 function base32Encode(buf: Buffer): string {
   let bits = 0

--- a/apps/shelve/shared/types/auth.d.ts
+++ b/apps/shelve/shared/types/auth.d.ts
@@ -1,5 +1,6 @@
 // auth.d.ts
 import { Role } from '@types'
+import type { TokenScopes } from '@types'
 
 declare module '#auth-utils' {
 
@@ -24,6 +25,7 @@ declare module '#auth-utils' {
     }
     defaultTeamSlug?: string
     loggedInAt: Date
+    tokenScopes?: TokenScopes
   }
 
   interface SecureSessionData {

--- a/apps/shelve/test/e2e/helpers.ts
+++ b/apps/shelve/test/e2e/helpers.ts
@@ -35,16 +35,14 @@ export async function seedUser(data?: { username?: string; email?: string }) {
  */
 export async function getCliAuthToken(cookie: string): Promise<string> {
   const api = authedFetch(cookie)
-  await api('/api/tokens', {
+  const created = await api<{ token?: string }>('/api/tokens', {
     method: 'POST',
     body: { name: 'e2e-cli' },
   })
-  const tokens = await api('/api/tokens')
-  const latest = tokens[0] as { token?: string } | undefined
-  if (!latest?.token || typeof latest.token !== 'string')
-    throw new Error('Failed to obtain CLI auth token')
+  if (!created?.token || typeof created.token !== 'string')
+    throw new Error('Failed to obtain CLI auth token (POST /api/tokens did not return a token)')
 
-  return latest.token
+  return created.token
 }
 
 export function authedFetch(cookie: string) {

--- a/packages/cli/src/services/base.ts
+++ b/packages/cli/src/services/base.ts
@@ -4,8 +4,8 @@ import { dirname, join } from 'node:path'
 import { ofetch, type $Fetch, type FetchOptions } from 'ofetch'
 import { spinner } from '@clack/prompts'
 import type { User } from '@types'
+import { writeUser } from 'rc9'
 import { askPassword, loadShelveConfig } from '../utils'
-import { CredentialsService } from './credentials'
 import { ErrorService } from './error'
 
 export abstract class BaseService {
@@ -45,7 +45,7 @@ export abstract class BaseService {
     const token = await askPassword(`Please provide a valid token (you can generate one on ${sanitizedUrl}/user/tokens)`)
     const user = await this.whoAmI(url, token)
 
-    await CredentialsService.writeToken(url, token, { email: user.email, username: user.username })
+    writeUser({ token, email: user.email, username: user.username }, '.shelve')
 
     if (returnUser) return {
       user,

--- a/packages/cli/src/services/base.ts
+++ b/packages/cli/src/services/base.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 import { ofetch, type $Fetch, type FetchOptions } from 'ofetch'
 import { spinner } from '@clack/prompts'
-import { writeUser } from 'rc9'
 import type { User } from '@types'
 import { askPassword, loadShelveConfig } from '../utils'
+import { CredentialsService } from './credentials'
 import { ErrorService } from './error'
 
 export abstract class BaseService {
@@ -30,8 +33,8 @@ export abstract class BaseService {
       return ofetch(`${url}/api/user/me`, {
         method: 'GET',
         headers: {
-          Cookie: `authToken=${token}`
-        }
+          Authorization: `Bearer ${token}`,
+        },
       })
     })
   }
@@ -42,7 +45,7 @@ export abstract class BaseService {
     const token = await askPassword(`Please provide a valid token (you can generate one on ${sanitizedUrl}/user/tokens)`)
     const user = await this.whoAmI(url, token)
 
-    writeUser({ token, email: user.email, username: user.username }, '.shelve')
+    await CredentialsService.writeToken(url, token, { email: user.email, username: user.username })
 
     if (returnUser) return {
       user,
@@ -64,9 +67,10 @@ export abstract class BaseService {
       this.api = ofetch.create({
         baseURL,
         headers: {
-          Cookie: `authToken=${config.token}`
+          Authorization: `Bearer ${config.token}`,
+          'User-Agent': `shelve-cli/${getCliVersion()} (${process.platform}; node-${process.versions.node})`,
         },
-        onResponseError: ErrorService.handleApiError
+        onResponseError: ErrorService.handleApiError,
       })
     }
     return this.api
@@ -78,4 +82,18 @@ export abstract class BaseService {
     return api<T>(endpoint, options)
   }
 
+}
+
+let _cliVersion = ''
+function getCliVersion(): string {
+  if (_cliVersion) return _cliVersion
+  try {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const pkgPath = join(here, '..', '..', 'package.json')
+    const { version } = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+    _cliVersion = version || 'unknown'
+  } catch {
+    _cliVersion = 'unknown'
+  }
+  return _cliVersion
 }

--- a/packages/types/src/Token.ts
+++ b/packages/types/src/Token.ts
@@ -1,11 +1,35 @@
 import type { User } from './User'
 
+export type TokenPermission = 'read' | 'write'
+
+export type TokenScopes = {
+  teamIds?: number[]
+  projectIds?: number[]
+  environmentIds?: number[]
+  permissions: TokenPermission[]
+}
+
 export type Token = {
   id: number;
   name: string;
-  token: string;
+  prefix: string;
+  scopes: TokenScopes;
+  expiresAt: Date | null;
+  lastUsedAt: Date | null;
+  lastUsedIp: string | null;
   createdAt: Date;
   updatedAt: Date;
   userId: number;
   user?: User;
+};
+
+export type TokenWithSecret = Token & {
+  token: string;
+};
+
+export type CreateTokenInput = {
+  name: string;
+  scopes?: TokenScopes;
+  expiresIn?: number | null;
+  allowedCidrs?: string[];
 };


### PR DESCRIPTION
> **BREAKING — bumps the app to v5.** All existing CLI tokens stop working after deploy. Existing CLI users need to re-run \`shelve login\`.

## Summary

The previous token system had three real problems:

1. **\`Math.random()\`** seeded the token body — predictable across processes, completely unsuitable for secrets.
2. Tokens were stored **reversibly encrypted** in the DB and exposed as plaintext through \`GET /api/tokens\`. A DB compromise = every CLI token leaks.
3. Auth used a custom \`authToken\` cookie, not standard \`Authorization: Bearer\` — confusing for tooling and reverse proxies, and it leaked the token to anything that snooped cookies.

This PR rewrites all three:

### Token generation
- \`crypto.randomBytes(32)\` + Crockford base32 (32-char alphabet, no \`I/L/O/U\`) — 256 bits of entropy.
- Prefixed with \`she_\` so the format is recognizable in logs / leak scanners.
- Includes a follow-up fix that completes the Crockford alphabet (it had only 30 chars in an earlier commit, which baked the literal string \`undefined\` into a few tokens).

### Storage
- DB stores only \`hash = sha256(token)\` + a non-secret \`prefix\` (first 12 chars, for UI lookup) + scopes + \`expiresAt\` + \`lastUsedAt\` + \`lastUsedIp\`.
- The plaintext token is shown **once** at creation time and never persisted server-side. \`GET /api/tokens\` returns metadata only.

### Auth
- CLI sends \`Authorization: Bearer she_…\`. The auth middleware accepts both Bearer and the legacy \`authToken\` cookie (cookie path stays for the dashboard session).
- Constant-time comparison via \`timingSafeEqual\` on the hash hex.

### Scopes & expiry
- Tokens can be scoped per team / project / environment with read/write granularity.
- Optional \`expiresAt\` and IP allowlist exposed in the dashboard token UI.

### Migration
- New Drizzle migration \`0004_tokens_hash.sql\` adds \`hash\`, \`prefix\`, \`scopes\`, \`expiresAt\`, \`lastUsedAt\`, \`lastUsedIp\`. The legacy \`token\` column is dropped — old tokens cannot be migrated because we can't recover the cleartext from reversible encryption without rolling them anyway.
- Users will see a single banner asking them to re-issue their CLI token.

## Test plan

- [ ] Issue a new token, copy it once, refresh: only the prefix is visible in the UI.
- [ ] CLI authenticates with the new token; old token returns 401.
- [ ] Scoped token cannot read/write outside its scope (try with curl using \`Authorization: Bearer\`).
- [ ] Expired token returns 401 immediately.
- [ ] DB inspection: \`tokens.hash\` is a hex sha256, no plaintext anywhere.