### PR TITLE
docs(lp): refresh documentation for v5 encryption, tokens, audit logs

### DIFF
--- a/.changeset/quiet-lizards-give.md
+++ b/.changeset/quiet-lizards-give.md
@@ -1,0 +1,5 @@
+---
+"shelve": patch
+---
+
+Docs: refresh the landing-page documentation to cover v5 features — envelope encryption (KEK/DEK), scoped API tokens, audit logs, and AI-agent safety from `shelve init`. Update CLI pages (`init`, `run`, `login`/`logout`) to reflect OS-keychain storage, encrypted offline cache, and the `.env.template` secret-reference syntax.

--- a/apps/lp/content/docs/1.getting-started/1.index.md
+++ b/apps/lp/content/docs/1.getting-started/1.index.md
@@ -12,39 +12,42 @@ Born from the frustration of sharing sensitive information through insecure chan
 
 ### Why Shelve?
 
-- Simple Setup: One login command to access all your projects
-- Team Focused: Built for modern development teams with seamless collaboration features and granular permissions.
-- Secure: Keep your secrets safe with end-to-end encryption and secure sharing mechanisms (SHA-256 hashing).
-- Open Source: Completely free and self-hostable, giving you full control over your data.
-- Developer Experience: CLI-first approach.
+- Simple setup: one command to log in, another to inject secrets at runtime.
+- Team focused: built for modern development teams with collaboration and granular permissions.
+- Secure by default: per-project envelope [encryption](/docs/core-features/encryption), OS-keychain token storage, [scoped API tokens](/docs/core-features/tokens), and [audit logs](/docs/core-features/audit-logs) on every write.
+- Open source: completely free and self-hostable, giving you full control over your data.
+- Developer experience: CLI-first, `.env`-free workflow with `shelve run`.
 
-### Key Features
+### Key features
 
-Environment Management
+Environment management
 
-- Centralized environment variable management across all your projects
-- Support for multiple environments (development, staging, production) and even custom environments
-- Secure variable sharing within teams
-- Easy import/export functionality
-- Team Collaboration
-- Role-based access control
-- Team workspaces
-- Activity monitoring
-- Secure member invitations
+- Centralized variable management across projects and teams.
+- First-class support for `development`, `preview`, `production`, plus custom environments.
+- Per-project data encryption keys (DEKs) sealed by a platform KEK — rotate scope is a single project.
+- Secret references (`shelve://ENV/KEY`) in `.env.template` for cross-environment composition.
+
+Team collaboration
+
+- Role-based access control on teams and projects.
+- Scoped, expiring API tokens with optional IP allowlists.
+- Full audit trail of team, project, variable, and token changes.
+- Secure member invitations.
 
 Integrations
 
-- GitHub secrets synchronization
-- One-click deployment using Coolify
-- Email authentication with OTP codes
-- OAuth authentication (GitHub, Google)
-- More integrations coming soon
+- GitHub secrets synchronization.
+- One-click deployment using Coolify.
+- Email authentication with OTP codes.
+- OAuth authentication (GitHub, Google).
+- Runtime injection into any process, CI, or container via `shelve run`.
 
-Developer Tools
+Developer tools
 
-- Powerful CLI for everyday operations
-- Docker support for self-hosting
-- Detailed documentation and examples
+- CLI with `init`, `login`, `run`, `pull`, `push`, `create`, `generate`, `config`, `upgrade`.
+- Encrypted offline cache — work from a plane, get variables back online automatically.
+- AI-agent safety: `init` provisions `.cursorignore` / `.aiderignore` / `.codeiumignore` files and never exposes secrets to your coding agent.
+- Docker image and Vercel deploy button for self-hosting.
 
 ### Getting Started
 

--- a/apps/lp/content/docs/1.getting-started/2.quickstart.md
+++ b/apps/lp/content/docs/1.getting-started/2.quickstart.md
@@ -71,9 +71,9 @@ This will prompt you to enter your token. Once you have entered your token, you 
       :::::accordion-item
       ---
       icon: i-lucide-refresh-cw
-      label: can i use the CLI in a CI/CD pipeline, for example, GitHub Actions?
+      label: Can I use the CLI in a CI/CD pipeline, for example GitHub Actions?
       ---
-      Actually, there is no way to use the CLI in a CI/CD pipeline. However, we are working on a complete solution for this use case, by using flags in the CLI commands to specify the token and the URL of the instance for example.
+      Yes. Create a scoped, expiring [API token](/docs/core-features/tokens) and expose it as `SHELVE_TOKEN` in your CI secrets. The CLI reads it directly — no `shelve login` needed. Pair it with `shelve run -- <your command>` to inject variables without writing a `.env` file on the runner.
       :::::
     
       :::::accordion-item{icon="i-lucide-search" label="What if I forget my token?"}

--- a/apps/lp/content/docs/2.core-features/audit-logs.md
+++ b/apps/lp/content/docs/2.core-features/audit-logs.md
@@ -1,0 +1,59 @@
+---
+title: Audit Logs
+description: Review every privileged action performed on your teams, projects, and secrets.
+---
+
+Every security-relevant action in Shelve is recorded in an append-only audit log. The feed is scoped to a team and visible to members with at least the required role.
+
+## What gets logged
+
+Among others:
+
+- `team.create`, `team.update`, `team.delete`, `team.member.add`, `team.member.role.update`, `team.member.remove`
+- `project.create`, `project.update`, `project.delete`
+- `environment.create`, `environment.update`, `environment.delete`
+- `variable.create`, `variable.update`, `variable.delete`, `variable.pull`, `variable.sync.github`
+- `token.create`, `token.delete`
+
+Every entry stores:
+
+- the **actor** (`user` with an id, `token` with the non-secret prefix, or `system` for scheduled jobs);
+- the **IP** (respecting the `X-Forwarded-For` chain on serverless / edge hosts);
+- the **user agent** (truncated to 256 chars);
+- the **resource** type and id;
+- an opaque **metadata** JSON blob — for example `{ "scopes": { "permissions": ["read"] } }` on `token.create` or `{ "count": 4 }` on `variable.create`.
+
+::callout{type="info"}
+Audit writes are fire-and-forget: they never block the originating request. If recording fails, the event is logged to the application logs and the request still succeeds.
+::
+
+## API
+
+Retrieve logs via the REST API:
+
+```bash [terminal]
+curl https://app.shelve.cloud/api/teams/<slug>/audit-logs \
+  -H "Authorization: Bearer $SHELVE_TOKEN"
+```
+
+### Query parameters
+
+::field-group
+  ::field{name="limit" type="number" default="50"}
+  Number of entries to return. Between 1 and 100.
+  ::
+
+  ::field{name="cursor" type="number"}
+  `id` of the last entry seen on the previous page. The API returns entries with smaller ids (newest first).
+  ::
+
+  ::field{name="action" type="string"}
+  Filter by action name (for example `variable.create`). Exact match.
+  ::
+::
+
+The response includes a `nextCursor` field — pass it back to fetch the next page until it is `null`.
+
+## Retention
+
+Audit logs are retained indefinitely on the hosted instance. On self-hosted deployments you control the retention policy by pruning the `audit_logs` table directly.

--- a/apps/lp/content/docs/2.core-features/encryption.md
+++ b/apps/lp/content/docs/2.core-features/encryption.md
@@ -1,0 +1,76 @@
+---
+title: Encryption
+description: How Shelve protects secrets at rest and in transit.
+---
+
+Shelve treats every secret value as encrypted data until the very moment you need it. This page describes the encryption scheme, the key hierarchy, and what actually hits the database.
+
+## Two-tier envelope encryption
+
+Secret values are never encrypted directly with the global server key. Instead Shelve uses an envelope scheme:
+
+```
+value ──seal──▶ ciphertext     (key = DEK, per-project)
+DEK   ──seal──▶ encryptedDek   (key = KEK, platform-wide)
+```
+
+- **KEK** — *Key Encryption Key*. A single secret sourced from `NUXT_PRIVATE_ENCRYPTION_KEY` at boot. It never touches stored data directly; it is only used to seal and unseal DEKs.
+- **DEK** — *Data Encryption Key*. Generated server-side on a project's first write (32 random bytes, base64-encoded), sealed with the KEK, and persisted in `projects.encryptedDek`. From then on every variable on that project is encrypted with that DEK.
+
+The sealing primitive underneath is [`iron-webcrypto`](https://github.com/brc-dd/iron-webcrypto), configured with authenticated encryption (`aes-256-gcm`). A tampered ciphertext fails to decrypt — there is no silent downgrade.
+
+## Why envelope encryption?
+
+::card-group
+  ::card{icon="i-lucide-zap"}
+  #title
+  Fast key rotation
+
+  #description
+  Rotating a project's DEK only re-encrypts that project's variables. A platform-wide rotation changes only the KEK; every sealed DEK is re-sealed once and business continues.
+  ::
+
+  ::card{icon="i-lucide-shield"}
+  #title
+  Scoped blast radius
+
+  #description
+  A leaked DEK compromises one project, not every secret on the instance. The KEK never leaves the server.
+  ::
+
+  ::card{icon="i-lucide-layers"}
+  #title
+  BYOK-ready
+
+  #description
+  The DEK layer is the seam where hardware-backed key storage (KMS, HSM, passkeys) will plug in without touching application code.
+  ::
+::
+
+## Backward compatibility
+
+Projects created before the envelope upgrade have no `encryptedDek` column value. Their variables keep decrypting directly with the KEK and the first new write provisions a DEK automatically. Reads tolerate mixed-state data: the service tries the project DEK first, then falls back to the KEK so no variable is left unreadable during the transition.
+
+## What is stored in the database
+
+| Column | What it holds |
+|---|---|
+| `variables.encryptedValue` | Sealed ciphertext of the secret value. Never plaintext. |
+| `projects.encryptedDek` | Project DEK, sealed by the KEK. `null` for pre-envelope projects. |
+| `tokens.hash` | `sha256(token)` as hex. The plaintext token is never stored. |
+| `tokens.prefix` | Non-secret 12-char prefix used for display and audit logs. |
+
+## API tokens
+
+API tokens follow a different (but compatible) model: they are hashed, not encrypted. See [API Tokens](/docs/core-features/tokens) for the full story.
+
+## In transit
+
+Traffic to `app.shelve.cloud` uses TLS 1.3 end-to-end. The CLI pins the same endpoint and refuses downgrade. For self-hosted instances, configure HTTPS at your reverse proxy or platform.
+
+## Self-host checklist
+
+1. Generate a strong KEK: `openssl rand -base64 48`.
+2. Set it as `NUXT_PRIVATE_ENCRYPTION_KEY` on your platform.
+3. **Never** rotate the KEK in-place without re-sealing existing DEKs — existing data becomes unreadable. A safe rotation procedure is on the [roadmap](https://github.com/HugoRCD/shelve/issues).
+4. Back up `projects.encryptedDek` alongside `variables.encryptedValue`; losing either makes the corresponding data unrecoverable.

--- a/apps/lp/content/docs/2.core-features/tokens.md
+++ b/apps/lp/content/docs/2.core-features/tokens.md
@@ -1,0 +1,56 @@
+---
+title: API Tokens
+description: Create, scope, and revoke API tokens for the CLI and integrations.
+---
+
+API tokens let the CLI and any external system authenticate against Shelve. They are managed from your account settings at [app.shelve.cloud/user/tokens](https://app.shelve.cloud/user/tokens).
+
+## How tokens are stored
+
+- The plaintext value is **shown exactly once**, at creation. Copy it immediately — Shelve never stores it and cannot retrieve it later.
+- Only the SHA-256 hash of the token is written to the database, alongside a non-secret prefix (`she_…` — the first 12 characters). The prefix is what you see in the token list and in audit logs; it is useful for identifying a token without revealing it.
+- Lookups run in constant time (`timingSafeEqual` on the hash), so there is no side channel that leaks bit-by-bit comparisons.
+
+::callout{type="info"}
+Tokens are produced from `crypto.randomBytes(32)` and encoded in [Crockford base32](https://www.crockford.com/base32.html). They are 256 bits of entropy and cannot be brute-forced.
+::
+
+## Scoped tokens
+
+By default a token inherits your account's full access. You can narrow it when creating the token:
+
+::field-group
+  ::field{name="permissions" type="('read' | 'write')[]"}
+  At least one is required. `read` grants listing and fetching, `write` grants mutations. A read-only token that tries to POST a variable receives `403 Token missing 'write' permission`.
+  ::
+
+  ::field{name="teamIds" type="number[]"}
+  Restrict the token to one or more teams. Requests targeting any other team return `403 Token not authorized for this team`.
+  ::
+
+  ::field{name="projectIds" type="number[]"}
+  Restrict the token to specific projects within the allowed teams.
+  ::
+
+  ::field{name="environmentIds" type="number[]"}
+  Restrict the token to specific environments. Useful for CI tokens that should only read `production` secrets, for example.
+  ::
+::
+
+Scope enforcement happens server-side in a dedicated middleware; the token can never outgrow the scope it was issued with.
+
+## Expiry
+
+Every token may carry an `expiresAt`. After that date the token is refused with `401 Token expired` even before it is hashed and matched. Rotating a short-lived CI token is as simple as creating a new one; no restart or config push is required.
+
+## IP allowlist
+
+Optionally attach a list of CIDR blocks to a token. Requests originating outside those blocks are rejected with `401 Token not authorized for this network`. Both IPv4 and IPv6 notations are supported.
+
+## Audit trail
+
+Token lifecycle events (`token.create`, `token.delete`) and every authenticated request surface in [audit logs](/docs/core-features/audit-logs) with the token prefix, actor, IP, and user agent. When something looks wrong, revoke the token from the UI — the hash is deleted and the next request using it returns `401`.
+
+## Sending tokens
+
+The CLI and any integration should send the token as an `Authorization: Bearer <token>` header. The legacy `Cookie: authToken=…` path still works for older CLI builds but returns `Deprecation: true` / `Sunset: Wed, 01 Jul 2026 00:00:00 GMT` response headers — migrate clients before that date.

--- a/apps/lp/content/docs/3.cli/1.init.md
+++ b/apps/lp/content/docs/3.cli/1.init.md
@@ -1,0 +1,38 @@
+---
+title: Init
+description: Scaffold AI-agent-safe ignore files in your project.
+---
+
+The `init` command prepares a repository for use with Shelve and, crucially, keeps your `.env*` files out of the context of AI coding agents. Running it is a one-off setup step — run it once per project.
+
+```bash [terminal]
+shelve init
+```
+
+## What it does
+
+- Creates (or updates) an ignore file for every major AI agent so they can never read cached secrets:
+  - `.cursorignore`
+  - `.aiderignore`
+  - `.codeiumignore`
+  - `.continueignore`
+  - `.aigignore`
+- Appends a managed block to your `.gitignore` if one is not already present, so the encrypted cache directory (`.shelve/`) and all `.env*` files stay out of version control. `.env.example` and `.env.template` are whitelisted so you can still commit references.
+
+Each ignore file is framed with `# shelve-managed-block` / `# end shelve-managed-block` markers. Running `shelve init` again only rewrites the managed block — your own entries above and below are preserved.
+
+## Options
+
+::field-group
+  ::field{name="cwd" type="string"}
+  Directory to initialize. Defaults to the current working directory.
+  ::
+::
+
+## Why this matters
+
+AI coding agents (Cursor, Claude Code, Codex, Aider, Continue…) can read every file in your workspace unless you tell them otherwise. If you ever run `shelve pull` to write a `.env` to disk, an agent can trivially exfiltrate its contents into a prompt or a suggested commit. `shelve init` closes that hole in one command.
+
+::callout{type="info"}
+Even with agent ignore files in place, prefer `shelve run -- <cmd>`: it pipes secrets to your subprocess through the environment and never writes them to disk in the first place.
+::

--- a/apps/lp/content/docs/3.cli/2.index.md
+++ b/apps/lp/content/docs/3.cli/2.index.md
@@ -108,7 +108,7 @@ Here are all the available options for the configuration file:
 |---------------------|-----------|----------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
 | `project`           | `string`  | `process.env.SHELVE_PROJECT` or nearest package.json name                              | The name of your project                                                |
 | `slug`              | `string`  | `process.env.SHELVE_TEAM_SLUG`                                                         | Your team slug (can be found in your team settings)                     |
-| `token`             | `string`  | Global token stored in `~/.shelve` after `shelve login`, or `process.env.SHELVE_TOKEN` | Authentication token created via app.shelve cloud/tokens                |
+| `token`             | `string`  | OS keychain (preferred) or `$XDG_CONFIG_HOME/.shelve` after `shelve login`, or `process.env.SHELVE_TOKEN` | Authentication token created via app.shelve.cloud/user/tokens           |
 | `url`               | `string`  | `https://app.shelve.cloud`                                                             | URL of the Shelve instance                                              |
 | `defaultEnv`        | `string`  |                                                                                        | The default environment use by the command like `run`, `push` or `pull` |
 | `confirmChanges`    | `boolean` | `false`                                                                                | Whether to confirm changes before applying them                         |

--- a/apps/lp/content/docs/3.cli/3.run.md
+++ b/apps/lp/content/docs/3.cli/3.run.md
@@ -1,54 +1,100 @@
 ---
 title: Run
-description: Inject secrets from Shelve into your application process
+description: Inject secrets into your application at runtime without writing a .env file.
 ---
 
-The `run` command allows you to inject secrets from Shelve into your application process.
-This command uses [`ni`](https://github.com/antfu-collective/ni) from [antfu](https://antfu.me/) under the hood to automatically detect you package manager and run the command.
-
-::warning
-This command is still experimental and may not work as expected.
-::
-
-## Usage
+`shelve run` spawns your command with every variable from your Shelve project already present in its environment. No `.env` file is written, no secret ever touches disk.
 
 ```bash [terminal]
-shelve run <command>
+shelve run -- <command> [args]
 ```
 
-### Examples
+The double-dash is conventional — anything after `--` is passed verbatim to your command. For simple npm-style scripts, `shelve run dev` works too: it uses [`ni`](https://github.com/antfu-collective/ni) to detect your package manager and run the script.
 
-:::code-group{sync="rc"}
-  ```bash [terminal]
-  shelve run dev
-  ```
+## How it works
 
-  ```bash [terminal]
-  shelve run dev:app
-  ```
-  
-  ```bash [terminal]
-  shelve run build
-  ```
-:::
+1. Shelve reads your token (from the OS keychain or the XDG config file), resolves your team / project / environment, and fetches the variables for that env.
+2. The variables are spliced into a fresh environment map and merged onto your process's environment.
+3. Your command is spawned via `node:child_process.spawn`, in its own process group, so Shelve can forward `SIGINT` / `SIGTERM` cleanly.
+4. The exit code of your command becomes the exit code of `shelve run` — seamless in CI.
 
-### Options
+## Examples
+
+```bash [terminal]
+# Run your dev server with production-like secrets
+shelve run --env=preview -- pnpm dev
+
+# Short form when the command is a package.json script
+shelve run build
+
+# Explicit command + flags
+shelve run -- node scripts/migrate.ts --dry-run
+```
+
+## Options
 
 ::field-group
-  ::field{name="command" type="string" required}
-  The command to run (e.g. `dev` or `build`)
+  ::field{name="env" type="string"}
+  Environment to use (for example `development`, `preview`, `production`). Overrides `defaultEnv` from `shelve.json`.
   ::
 
-  ::field{name="env" type="string"}
-  The environment to use (e.g. `development`, `staging`, `production`).
+  ::field{name="watch" type="boolean"}
+  Restart the child process whenever variables change upstream. Combine with a dev server that already reloads on source edits.
+  ::
+
+  ::field{name="offline" type="'auto' | 'never' | 'only'" default="'auto'"}
+  How to use the encrypted offline cache. `auto` (default) refreshes variables from Shelve and falls back to the cache if the network is down. `never` disables the cache entirely. `only` refuses to make any network call.
+  ::
+
+  ::field{name="cache-ttl" type="duration" default="15m"}
+  How long a cached payload is considered fresh. Accepts `500ms`, `30s`, `15m`, `2h`, `7d`, or a raw number in milliseconds.
   ::
 ::
 
-You can configure a default environment in your `shelve.json` file to bypass the env prompt:
+## Secret references (`.env.template`)
 
-```json [shelve.json]
-{
-  "defaultEnv": "development",
-  "slug": "shelve"
-}
+If a `.env.template` file is present in the current directory, Shelve uses it as a **layout** for the injected environment. Each line is either a literal value or a `shelve://` reference that resolves against the current environment:
+
+```bash [.env.template]
+NODE_ENV=production
+DATABASE_URL=shelve://DATABASE_URL
+PROD_DATABASE_URL=shelve://production/DATABASE_URL
 ```
+
+- Lines without `shelve://` pass through verbatim.
+- `shelve://KEY` pulls `KEY` from the current environment, optionally renaming it on the left-hand side.
+- `shelve://<env>/KEY` explicitly targets another environment — useful for mirroring production values into a preview command.
+
+References that cannot be resolved are reported in a grouped diagnostic and the command aborts before spawning the child, so you never run a process with partially-hydrated secrets.
+
+## Encrypted offline cache
+
+After every successful fetch, Shelve writes the payload to `~/.shelve/cache/<hash>.cache`, sealed with a key derived from your current token via HKDF. The cache is scoped per team + project + environment; switching environments uses a different key.
+
+- Loss of the token invalidates the cache automatically (the derived key no longer matches).
+- Tampering with the cache file is detected via AES-GCM authentication tags — a modified file fails to decrypt.
+- Files are created with `0600` permissions; the directory with `0700`.
+
+Use `--offline=only` on planes, in restricted CI environments, or anywhere outbound egress is blocked.
+
+## Watch mode
+
+```bash [terminal]
+shelve run --watch -- node server.js
+```
+
+With `--watch`, Shelve opens a server-sent events stream and listens for `variable.updated` / `variable.deleted` events on your project. When a change lands the child process is sent `SIGTERM`, waits for it to exit (or is killed after a grace period), and is respawned with the new environment. This is the closest thing to a managed "hot reload for secrets".
+
+## AI-agent safety
+
+When `shelve run` is invoked from a shell whose environment looks like an AI coding agent (Cursor, Claude Code, Aider, Continue, Codex, …), it prints a reminder that secrets will only exist in the spawned process's memory and will never be visible to the agent itself. Unlike `shelve pull`, `run` never prompts — running with an agent attached is safe by design.
+
+## Exit behaviour
+
+| Signal / event | Behaviour |
+|---|---|
+| Child exits normally | `shelve run` exits with the same code |
+| Child crashes | Shelve propagates the exit code |
+| `Ctrl-C` (`SIGINT`) | Forwarded to the entire process group; child terminates cleanly |
+| `SIGTERM` | Forwarded to the process group, grace period 5s, then `SIGKILL` |
+| Variable change (watch mode) | Child is respawned with the new env |

--- a/apps/lp/content/docs/3.cli/4.login-logout.md
+++ b/apps/lp/content/docs/3.cli/4.login-logout.md
@@ -1,40 +1,55 @@
 ---
 title: Login and Logout
-description: Authenticate with Shelve CLI.
+description: Authenticate the CLI against Shelve and manage stored credentials.
 ---
 
 ## Login
-
-The `login` command allows you to authenticate with Shelve CLI, which is required to access your Shelve projects securely.
 
 ```bash [terminal]
 shelve login
 ```
 
-When you run the `login` command, you will be prompted to enter a token. You can find your token in the Shelve dashboard under the [`API Tokens`](https://app.shelve.cloud/user/tokens) tab.
+The CLI prompts for a token. Create one from the Shelve dashboard at [app.shelve.cloud/user/tokens](https://app.shelve.cloud/user/tokens), then paste it into the prompt. Tokens are [scopeable, expiring, and IP-bound](/docs/core-features/tokens) — prefer a narrowly-scoped token to your account-wide default.
 
-::warning
-For the moment, you cannot add multiple users, if you want to change the user, you need to log out and log in again.
+### Where the token is stored
+
+1. **OS keychain first** — Keychain on macOS, Credential Vault on Windows, Secret Service / GNOME Keyring / KWallet on Linux (via [`@napi-rs/keyring`](https://github.com/napi-rs/keyring)). The value is encrypted at rest and gated by the OS session.
+2. **XDG file fallback** — if the keychain is unavailable (headless CI containers, missing D-Bus on Linux, …) the CLI writes to `$XDG_CONFIG_HOME/.shelve` (typically `~/.config/.shelve`) with mode `0600`. A warning is printed so you know you are on the fallback path.
+
+::callout{type="info"}
+Older CLI versions wrote credentials to `~/.shelve`. The first `login` / `logout` / `pull` you run with a v5 CLI will migrate the legacy file into the XDG location and delete the original.
 ::
 
 ### Me
-
-The `me` command allows you to view your user information.
 
 ```bash [terminal]
 shelve me
 ```
 
-## Logout
+Prints the account the current token is attached to, the Shelve instance URL, and which storage backend holds the token.
 
-The `logout` command allows you to log out from Shelve CLI.
+## Logout
 
 ```bash [terminal]
 shelve logout
 ```
 
-This will delete the token stored in your local machine and log you out from Shelve CLI.
+Removes the token from the keychain (if present) and clears the XDG config. Subsequent CLI commands refuse to run until you log in again.
 
-### Options
+## Non-interactive environments
 
-Soon
+In CI, a container, or any automation flow, skip `shelve login` entirely and pass the token via an environment variable:
+
+```bash [terminal]
+SHELVE_TOKEN="$SHELVE_TOKEN" shelve run -- pnpm test
+```
+
+The CLI reads `SHELVE_TOKEN` before consulting the keychain or the XDG file. Pair it with a scoped, expiring token for least-privilege CI access.
+
+::callout{type="warning"}
+Never commit `SHELVE_TOKEN` to git. Use your CI provider's secrets UI or a runtime secret store (GitHub Actions secrets, Vercel project env vars, …).
+::
+
+## Multiple accounts
+
+Only one account per machine is supported at a time. To switch accounts, `shelve logout` and `shelve login` again with the new token.

--- a/apps/lp/content/docs/5.self-hosting/2.environment-variables.md
+++ b/apps/lp/content/docs/5.self-hosting/2.environment-variables.md
@@ -30,12 +30,12 @@ These environment variables are **mandatory** for Shelve to function:
 ### `NUXT_PRIVATE_ENCRYPTION_KEY`
 - **Type**: String
 - **Required**: ✅ Yes
-- **Constraint**: Minimum 32 characters  
-- **Description**: Master key to encrypt sensitive data in the database
+- **Constraint**: Minimum 32 characters
+- **Description**: Key Encryption Key (KEK). Used to seal the per-project Data Encryption Keys (DEKs) that actually protect variable values. See [Encryption](/docs/core-features/encryption) for the full model.
 - **Generation**: `openssl rand -base64 48`
 
 ::callout{type="warning"}
-**Important**: Never modify these keys after first deployment, it would make existing data inaccessible.
+**Important**: Never modify these keys after first deployment, it would make existing data inaccessible. A safe KEK rotation flow (re-sealing all DEKs) is on the roadmap.
 ::
 
 ## Authentication configuration


### PR DESCRIPTION
## Summary

Refresh the landing-page docs to match the v5 surface that shipped with the envelope-encryption / audit / scoped-token release.

## Changes

**New core-feature pages** (`apps/lp/content/docs/2.core-features/`)

- `encryption.md` — envelope scheme (platform KEK + per-project DEK), `iron-webcrypto` primitive, backward-compat with pre-envelope projects, storage layout, self-host checklist.
- `tokens.md` — SHA-256 hashing, non-secret prefix, Crockford base32 generation, scoped permissions, team/project/env restrictions, expiry, IP allowlisting, Bearer vs deprecated cookie auth.
- `audit-logs.md` — logged actions (team/project/variable/token), entry schema, fire-and-forget write model, API query params (`limit`, `cursor`, `action`), retention.

**New CLI page** (`apps/lp/content/docs/3.cli/`)

- `1.init.md` — `shelve init` writes `.cursorignore` / `.aiderignore` / `.codeiumignore` and updates `.gitignore`; keeps agents out of `.env*` and `.shelve/`.

**Refreshed CLI pages**

- `3.run.md` — offline cache model, `--offline` / `--cache-ttl`, `.env.template` secret references (`shelve://ENV/KEY`), watch mode, agent safety, exit behaviour.
- `4.login-logout.md` — OS keychain storage via `@napi-rs/keyring`, XDG file fallback, legacy `~/.shelve` migration, `SHELVE_TOKEN` for CI.
- `2.index.md` — update the token-storage column to match v5.

**Other**

- `1.getting-started/1.index.md` — updated feature list with links to new pages.
- `1.getting-started/2.quickstart.md` — rewrite the "CLI in CI/CD" FAQ entry now that `SHELVE_TOKEN` + `shelve run` cover the use case.
- `5.self-hosting/2.environment-variables.md` — clarify that `NUXT_PRIVATE_ENCRYPTION_KEY` is the KEK, link the new encryption page.

## Test plan

- [ ] `pnpm --filter=shelve-lp dev` and verify the four new pages render.
- [ ] Check the sidebar order (`1.init.md` at the top of the CLI section, new pages visible under Core features).
- [ ] Skim for broken links (`/docs/core-features/encryption`, `/docs/core-features/tokens`, `/docs/core-features/audit-logs`).