### PR TITLE
feat(lp): showcase v5 security surface on the landing page

### DIFF
--- a/.changeset/lp-v5-features.md
+++ b/.changeset/lp-v5-features.md
@@ -1,0 +1,5 @@
+---
+"shelve": patch
+---
+
+Landing page: showcase the v5 security surface — new sections for envelope encryption, scoped API tokens, audit logs, and AI-agent safety, each with a dedicated visual component. Refresh the FAQ to reflect the new encryption model, token hashing, and agent-safety workflow.

--- a/apps/lp/app/components/landing/AgentSafety.vue
+++ b/apps/lp/app/components/landing/AgentSafety.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const ignored = ['.env', '.env.local', '.env.production', '.shelve/']
+</script>
+
+<template>
+  <div class="relative flex items-center justify-center w-full">
+    <div class="grid grid-cols-[1fr_auto_1fr] gap-4 items-center w-full max-w-[380px]">
+      <div class="flex flex-col items-center gap-2 rounded-lg bg-default/60 backdrop-blur-lg ring-1 ring-default p-3 shadow-sm">
+        <div class="flex size-10 items-center justify-center rounded-md bg-elevated/50">
+          <UIcon name="lucide:bot" class="size-5 text-muted" />
+        </div>
+        <span class="text-xs font-semibold">AI agent</span>
+        <span class="text-[10px] text-muted">Cursor · Claude · Aider</span>
+      </div>
+
+      <div class="flex flex-col items-center gap-1">
+        <UIcon name="lucide:shield" class="size-5 text-primary" />
+        <span class="text-[10px] text-muted font-mono">.cursorignore</span>
+      </div>
+
+      <div class="flex flex-col gap-1.5 rounded-lg bg-default/60 backdrop-blur-lg ring-1 ring-default p-3 shadow-sm">
+        <span class="text-xs font-semibold text-default mb-1">Hidden from agent</span>
+        <div
+          v-for="file in ignored"
+          :key="file"
+          class="flex items-center gap-1.5 font-mono text-[11px] text-muted"
+        >
+          <UIcon name="lucide:eye-off" class="size-3 shrink-0" />
+          <span class="truncate">{{ file }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/lp/app/components/landing/AuditLogs.vue
+++ b/apps/lp/app/components/landing/AuditLogs.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 const entries = [
-  { action: 'variable.update', actor: 'hugo', resource: 'production/STRIPE_SECRET_KEY', ago: '12s', icon: 'lucide:pencil', color: 'text-warning' },
-  { action: 'token.create', actor: 'hugo', resource: 'ci-deploy', ago: '2m', icon: 'lucide:key-round', color: 'text-primary' },
-  { action: 'variable.delete', actor: 'paul', resource: 'preview/LEGACY_FLAG', ago: '14m', icon: 'lucide:trash-2', color: 'text-error' },
-  { action: 'team.member.invite', actor: 'hugo', resource: 'amy@shelve.cloud', ago: '1h', icon: 'lucide:user-plus', color: 'text-success' },
-  { action: 'project.create', actor: 'paul', resource: '@shelve/docs', ago: '3h', icon: 'lucide:folder-plus', color: 'text-muted' }
+  { action: 'variable.update', actor: 'owner', resource: 'production/STRIPE_SECRET_KEY', ago: '12s', icon: 'lucide:pencil', color: 'text-warning' },
+  { action: 'token.create', actor: 'owner', resource: 'ci-deploy', ago: '2m', icon: 'lucide:key-round', color: 'text-primary' },
+  { action: 'variable.delete', actor: 'admin', resource: 'preview/LEGACY_FLAG', ago: '14m', icon: 'lucide:trash-2', color: 'text-error' },
+  { action: 'team.member.invite', actor: 'owner', resource: 'teammate@example.com', ago: '1h', icon: 'lucide:user-plus', color: 'text-success' },
+  { action: 'project.create', actor: 'admin', resource: 'web-platform', ago: '3h', icon: 'lucide:folder-plus', color: 'text-muted' }
 ]
 </script>
 

--- a/apps/lp/app/components/landing/AuditLogs.vue
+++ b/apps/lp/app/components/landing/AuditLogs.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+const entries = [
+  { action: 'variable.update', actor: 'hugo', resource: 'production/STRIPE_SECRET_KEY', ago: '12s', icon: 'lucide:pencil', color: 'text-warning' },
+  { action: 'token.create', actor: 'hugo', resource: 'ci-deploy', ago: '2m', icon: 'lucide:key-round', color: 'text-primary' },
+  { action: 'variable.delete', actor: 'paul', resource: 'preview/LEGACY_FLAG', ago: '14m', icon: 'lucide:trash-2', color: 'text-error' },
+  { action: 'team.member.invite', actor: 'hugo', resource: 'amy@shelve.cloud', ago: '1h', icon: 'lucide:user-plus', color: 'text-success' },
+  { action: 'project.create', actor: 'paul', resource: '@shelve/docs', ago: '3h', icon: 'lucide:folder-plus', color: 'text-muted' }
+]
+</script>
+
+<template>
+  <div class="w-full max-w-[380px]">
+    <div class="rounded-lg bg-default/60 backdrop-blur-lg ring-1 ring-default shadow-xl overflow-hidden">
+      <div class="flex items-center justify-between border-b border-default px-3 py-2">
+        <div class="flex items-center gap-2">
+          <UIcon name="lucide:history" class="size-4 text-muted" />
+          <span class="text-xs font-semibold">Audit log</span>
+        </div>
+        <span class="text-[10px] text-muted font-mono">/api/teams/shelve/audit-logs</span>
+      </div>
+      <ul class="divide-y divide-default">
+        <li v-for="entry in entries" :key="entry.action + entry.resource" class="flex items-start gap-3 px-3 py-2.5">
+          <div class="flex size-7 items-center justify-center rounded-md bg-elevated/50 shrink-0">
+            <UIcon :name="entry.icon" class="size-3.5" :class="entry.color" />
+          </div>
+          <div class="flex flex-1 flex-col min-w-0">
+            <div class="flex items-center gap-2 text-xs">
+              <span class="font-mono text-default truncate">{{ entry.action }}</span>
+              <span class="text-muted shrink-0">·</span>
+              <span class="text-muted shrink-0">{{ entry.actor }}</span>
+            </div>
+            <span class="text-[11px] text-muted truncate">{{ entry.resource }}</span>
+          </div>
+          <span class="text-[10px] text-muted font-mono shrink-0 pt-0.5">{{ entry.ago }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/apps/lp/app/components/landing/Encryption.vue
+++ b/apps/lp/app/components/landing/Encryption.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+const layers = [
+  { id: 'kek', label: 'KEK', sub: 'platform', icon: 'lucide:shield', ring: 'ring-primary/40' },
+  { id: 'dek', label: 'DEK', sub: 'per project', icon: 'lucide:key-round', ring: 'ring-default' },
+  { id: 'value', label: 'ciphertext', sub: 'variables.encryptedValue', icon: 'lucide:lock', ring: 'ring-default' }
+]
+</script>
+
+<template>
+  <div class="relative flex flex-col items-center justify-center gap-4 w-full max-w-[340px] mx-auto">
+    <div
+      v-for="(layer, index) in layers"
+      :key="layer.id"
+      class="envelope-row relative w-full flex items-center gap-3 rounded-md bg-default/60 backdrop-blur-lg ring-1 p-3 shadow-sm"
+      :class="[layer.ring]"
+      :style="{ '--delay': `${index * 0.15}s` }"
+    >
+      <div class="flex size-10 items-center justify-center rounded-md border border-default bg-elevated/40">
+        <UIcon :name="layer.icon" class="size-5 text-muted" />
+      </div>
+      <div class="flex flex-col text-left">
+        <span class="text-sm font-semibold text-default">{{ layer.label }}</span>
+        <span class="text-xs text-muted">{{ layer.sub }}</span>
+      </div>
+      <UIcon v-if="index < layers.length - 1" name="lucide:arrow-down" class="absolute -bottom-3.5 left-1/2 -translate-x-1/2 size-4 text-muted" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.envelope-row {
+  animation: seal 3s ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+@keyframes seal {
+  0%, 70%, 100% { transform: translateY(0); opacity: 1; }
+  35% { transform: translateY(-2px); opacity: 0.85; }
+}
+</style>

--- a/apps/lp/app/components/landing/Encryption.vue
+++ b/apps/lp/app/components/landing/Encryption.vue
@@ -7,34 +7,54 @@ const layers = [
 </script>
 
 <template>
-  <div class="relative flex flex-col items-center justify-center gap-4 w-full max-w-[340px] mx-auto">
-    <div
-      v-for="(layer, index) in layers"
-      :key="layer.id"
-      class="envelope-row relative w-full flex items-center gap-3 rounded-md bg-default/60 backdrop-blur-lg ring-1 p-3 shadow-sm"
-      :class="[layer.ring]"
-      :style="{ '--delay': `${index * 0.15}s` }"
-    >
-      <div class="flex size-10 items-center justify-center rounded-md border border-default bg-elevated/40">
-        <UIcon :name="layer.icon" class="size-5 text-muted" />
+  <div class="flex w-full max-w-[340px] flex-col items-stretch mx-auto">
+    <template v-for="(layer, index) in layers" :key="layer.id">
+      <div
+        class="envelope-row flex w-full items-center gap-3 rounded-md bg-default/60 p-3 shadow-sm ring-1 backdrop-blur-lg"
+        :class="[layer.ring]"
+        :style="{ '--delay': `${index * 0.18}s` }"
+      >
+        <div class="flex size-10 shrink-0 items-center justify-center rounded-md border border-default bg-elevated/40">
+          <UIcon :name="layer.icon" class="size-5 text-muted" />
+        </div>
+        <div class="flex flex-col text-left">
+          <span class="text-sm font-semibold text-default">{{ layer.label }}</span>
+          <span class="text-xs text-muted">{{ layer.sub }}</span>
+        </div>
       </div>
-      <div class="flex flex-col text-left">
-        <span class="text-sm font-semibold text-default">{{ layer.label }}</span>
-        <span class="text-xs text-muted">{{ layer.sub }}</span>
+
+      <div
+        v-if="index < layers.length - 1"
+        class="envelope-arrow flex h-6 items-center justify-center"
+        :style="{ '--delay': `${index * 0.18 + 0.09}s` }"
+        aria-hidden="true"
+      >
+        <span class="block h-3 w-px bg-default/60" />
+        <UIcon name="lucide:chevron-down" class="-mx-px size-4 text-muted" />
+        <span class="block h-3 w-px bg-default/60" />
       </div>
-      <UIcon v-if="index < layers.length - 1" name="lucide:arrow-down" class="absolute -bottom-3.5 left-1/2 -translate-x-1/2 size-4 text-muted" />
-    </div>
+    </template>
   </div>
 </template>
 
 <style scoped>
 .envelope-row {
-  animation: seal 3s ease-in-out infinite;
+  animation: seal 3.2s ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+.envelope-arrow {
+  animation: flow 3.2s ease-in-out infinite;
   animation-delay: var(--delay);
 }
 
 @keyframes seal {
   0%, 70%, 100% { transform: translateY(0); opacity: 1; }
-  35% { transform: translateY(-2px); opacity: 0.85; }
+  35% { transform: translateY(-1px); opacity: 0.9; }
+}
+
+@keyframes flow {
+  0%, 100% { opacity: 0.4; transform: translateY(0); }
+  50% { opacity: 1; transform: translateY(2px); }
 }
 </style>

--- a/apps/lp/app/components/landing/Tokens.vue
+++ b/apps/lp/app/components/landing/Tokens.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+const prefix = 'shv_01JB7FA2TX'
+const scopes = [
+  { label: 'variable:read', color: 'text-success' },
+  { label: 'variable:write', color: 'text-success' },
+  { label: 'audit:read', color: 'text-muted' }
+]
+</script>
+
+<template>
+  <div class="relative flex items-center justify-center w-full">
+    <div class="relative w-[320px] rounded-xl bg-default/60 backdrop-blur-lg ring-1 ring-default shadow-xl p-4 flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <div class="flex size-8 items-center justify-center rounded-md bg-elevated">
+            <UIcon name="lucide:key-round" class="size-4 text-muted" />
+          </div>
+          <div class="flex flex-col">
+            <span class="text-sm font-semibold">ci-deploy</span>
+            <span class="text-xs text-muted">created 2h ago</span>
+          </div>
+        </div>
+        <span class="rounded-full bg-success/10 text-success text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5">active</span>
+      </div>
+
+      <div class="rounded-md bg-elevated/40 px-3 py-2 font-mono text-xs text-muted flex items-center justify-between">
+        <span>{{ prefix }}••••••••••••••••</span>
+        <UIcon name="lucide:eye-off" class="size-3.5" />
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <div class="flex items-center justify-between text-xs">
+          <span class="text-muted">Scope</span>
+          <div class="flex flex-wrap justify-end gap-1">
+            <span v-for="scope in scopes" :key="scope.label" class="rounded bg-elevated px-1.5 py-0.5 font-mono text-[10px]" :class="scope.color">
+              {{ scope.label }}
+            </span>
+          </div>
+        </div>
+        <div class="flex items-center justify-between text-xs">
+          <span class="text-muted">Expires</span>
+          <span class="font-mono">in 7 days</span>
+        </div>
+        <div class="flex items-center justify-between text-xs">
+          <span class="text-muted">IP allowlist</span>
+          <span class="font-mono text-default">10.0.0.0/8</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/lp/app/pages/index.vue
+++ b/apps/lp/app/pages/index.vue
@@ -1,4 +1,16 @@
 <script setup lang="ts">
+import {
+  LandingInstall,
+  LandingEncryption,
+  LandingTokens,
+  LandingAuditLogs,
+  LandingAgentSafety,
+  LandingEnvCheck,
+  LandingGithubSync,
+  LandingTeams,
+  LandingConsole,
+} from '#components'
+
 const { title, description, ogImage } = useAppConfig()
 
 const { data: page } = await useAsyncData('index', () => queryCollection('index').first())
@@ -16,6 +28,25 @@ useSeoMeta({
 })
 
 useSeoMeta({ ogImage: ogImage })
+
+type SectionVisual = Component | null
+
+const sectionVisuals: Record<string, SectionVisual> = {
+  secrets: LandingInstall,
+  encryption: LandingEncryption,
+  tokens: LandingTokens,
+  audit: LandingAuditLogs,
+  agent: LandingAgentSafety,
+  env: LandingEnvCheck,
+  github: LandingGithubSync,
+  team: LandingTeams,
+  console: LandingConsole,
+}
+
+function visualFor(id: string | undefined): SectionVisual {
+  if (!id) return null
+  return sectionVisuals[id] ?? null
+}
 </script>
 
 <template>
@@ -26,7 +57,7 @@ useSeoMeta({ ogImage: ogImage })
       <BgGradient />
       <UPageSection
         v-for="(section, index) in page.sections"
-        :key="index"
+        :key="section.id ?? index"
         :description="section.description"
         :links="section.links"
         orientation="horizontal"
@@ -56,15 +87,7 @@ useSeoMeta({ ogImage: ogImage })
           </Motion>
         </template>
         <div class="min-h-[300px] flex items-center justify-center">
-          <LandingInstall v-if="section.id === 'secrets'" />
-          <LandingEncryption v-if="section.id === 'encryption'" />
-          <LandingTokens v-if="section.id === 'tokens'" />
-          <LandingAuditLogs v-if="section.id === 'audit'" />
-          <LandingAgentSafety v-if="section.id === 'agent'" />
-          <LandingEnvCheck v-if="section.id === 'env'" />
-          <LandingGithubSync v-if="section.id === 'github'" />
-          <LandingTeams v-if="section.id === 'team'" />
-          <LandingConsole v-if="section.id === 'console'" />
+          <component :is="visualFor(section.id)" v-if="visualFor(section.id)" />
         </div>
       </UPageSection>
     </div>

--- a/apps/lp/app/pages/index.vue
+++ b/apps/lp/app/pages/index.vue
@@ -57,6 +57,10 @@ useSeoMeta({ ogImage: ogImage })
         </template>
         <div class="min-h-[300px] flex items-center justify-center">
           <LandingInstall v-if="section.id === 'secrets'" />
+          <LandingEncryption v-if="section.id === 'encryption'" />
+          <LandingTokens v-if="section.id === 'tokens'" />
+          <LandingAuditLogs v-if="section.id === 'audit'" />
+          <LandingAgentSafety v-if="section.id === 'agent'" />
           <LandingEnvCheck v-if="section.id === 'env'" />
           <LandingGithubSync v-if="section.id === 'github'" />
           <LandingTeams v-if="section.id === 'team'" />

--- a/apps/lp/content/docs/2.core-features/audit-logs.md
+++ b/apps/lp/content/docs/2.core-features/audit-logs.md
@@ -1,0 +1,59 @@
+---
+title: Audit Logs
+description: Review every privileged action performed on your teams, projects, and secrets.
+---
+
+Every security-relevant action in Shelve is recorded in an append-only audit log. The feed is scoped to a team and visible to members with at least the required role.
+
+## What gets logged
+
+Among others:
+
+- `team.create`, `team.update`, `team.delete`, `team.member.add`, `team.member.role.update`, `team.member.remove`
+- `project.create`, `project.update`, `project.delete`
+- `environment.create`, `environment.update`, `environment.delete`
+- `variable.create`, `variable.update`, `variable.delete`, `variable.pull`, `variable.sync.github`
+- `token.create`, `token.delete`
+
+Every entry stores:
+
+- the **actor** (`user` with an id, `token` with the non-secret prefix, or `system` for scheduled jobs);
+- the **IP** (respecting the `X-Forwarded-For` chain on serverless / edge hosts);
+- the **user agent** (truncated to 256 chars);
+- the **resource** type and id;
+- an opaque **metadata** JSON blob — for example `{ "scopes": { "permissions": ["read"] } }` on `token.create` or `{ "count": 4 }` on `variable.create`.
+
+::callout{type="info"}
+Audit writes are fire-and-forget: they never block the originating request. If recording fails, the event is logged to the application logs and the request still succeeds.
+::
+
+## API
+
+Retrieve logs via the REST API:
+
+```bash [terminal]
+curl https://app.shelve.cloud/api/teams/<slug>/audit-logs \
+  -H "Authorization: Bearer $SHELVE_TOKEN"
+```
+
+### Query parameters
+
+::field-group
+  ::field{name="limit" type="number" default="50"}
+  Number of entries to return. Between 1 and 100.
+  ::
+
+  ::field{name="cursor" type="number"}
+  `id` of the last entry seen on the previous page. The API returns entries with smaller ids (newest first).
+  ::
+
+  ::field{name="action" type="string"}
+  Filter by action name (for example `variable.create`). Exact match.
+  ::
+::
+
+The response includes a `nextCursor` field — pass it back to fetch the next page until it is `null`.
+
+## Retention
+
+Audit logs are retained indefinitely on the hosted instance. On self-hosted deployments you control the retention policy by pruning the `audit_logs` table directly.

--- a/apps/lp/content/docs/2.core-features/encryption.md
+++ b/apps/lp/content/docs/2.core-features/encryption.md
@@ -1,0 +1,76 @@
+---
+title: Encryption
+description: How Shelve protects secrets at rest and in transit.
+---
+
+Shelve treats every secret value as encrypted data until the very moment you need it. This page describes the encryption scheme, the key hierarchy, and what actually hits the database.
+
+## Two-tier envelope encryption
+
+Secret values are never encrypted directly with the global server key. Instead Shelve uses an envelope scheme:
+
+```
+value ──seal──▶ ciphertext     (key = DEK, per-project)
+DEK   ──seal──▶ encryptedDek   (key = KEK, platform-wide)
+```
+
+- **KEK** — *Key Encryption Key*. A single secret sourced from `NUXT_PRIVATE_ENCRYPTION_KEY` at boot. It never touches stored data directly; it is only used to seal and unseal DEKs.
+- **DEK** — *Data Encryption Key*. Generated server-side on a project's first write (32 random bytes, base64-encoded), sealed with the KEK, and persisted in `projects.encryptedDek`. From then on every variable on that project is encrypted with that DEK.
+
+The sealing primitive underneath is [`iron-webcrypto`](https://github.com/brc-dd/iron-webcrypto), configured with authenticated encryption (`aes-256-gcm`). A tampered ciphertext fails to decrypt — there is no silent downgrade.
+
+## Why envelope encryption?
+
+::card-group
+  ::card{icon="i-lucide-zap"}
+  #title
+  Fast key rotation
+
+  #description
+  Rotating a project's DEK only re-encrypts that project's variables. A platform-wide rotation changes only the KEK; every sealed DEK is re-sealed once and business continues.
+  ::
+
+  ::card{icon="i-lucide-shield"}
+  #title
+  Scoped blast radius
+
+  #description
+  A leaked DEK compromises one project, not every secret on the instance. The KEK never leaves the server.
+  ::
+
+  ::card{icon="i-lucide-layers"}
+  #title
+  BYOK-ready
+
+  #description
+  The DEK layer is the seam where hardware-backed key storage (KMS, HSM, passkeys) will plug in without touching application code.
+  ::
+::
+
+## Backward compatibility
+
+Projects created before the envelope upgrade have no `encryptedDek` column value. Their variables keep decrypting directly with the KEK and the first new write provisions a DEK automatically. Reads tolerate mixed-state data: the service tries the project DEK first, then falls back to the KEK so no variable is left unreadable during the transition.
+
+## What is stored in the database
+
+| Column | What it holds |
+|---|---|
+| `variables.encryptedValue` | Sealed ciphertext of the secret value. Never plaintext. |
+| `projects.encryptedDek` | Project DEK, sealed by the KEK. `null` for pre-envelope projects. |
+| `tokens.hash` | `sha256(token)` as hex. The plaintext token is never stored. |
+| `tokens.prefix` | Non-secret 12-char prefix used for display and audit logs. |
+
+## API tokens
+
+API tokens follow a different (but compatible) model: they are hashed, not encrypted. See [API Tokens](/docs/core-features/tokens) for the full story.
+
+## In transit
+
+Traffic to `app.shelve.cloud` uses TLS 1.3 end-to-end. The CLI pins the same endpoint and refuses downgrade. For self-hosted instances, configure HTTPS at your reverse proxy or platform.
+
+## Self-host checklist
+
+1. Generate a strong KEK: `openssl rand -base64 48`.
+2. Set it as `NUXT_PRIVATE_ENCRYPTION_KEY` on your platform.
+3. **Never** rotate the KEK in-place without re-sealing existing DEKs — existing data becomes unreadable. A safe rotation procedure is on the [roadmap](https://github.com/HugoRCD/shelve/issues).
+4. Back up `projects.encryptedDek` alongside `variables.encryptedValue`; losing either makes the corresponding data unrecoverable.

--- a/apps/lp/content/docs/2.core-features/tokens.md
+++ b/apps/lp/content/docs/2.core-features/tokens.md
@@ -1,0 +1,56 @@
+---
+title: API Tokens
+description: Create, scope, and revoke API tokens for the CLI and integrations.
+---
+
+API tokens let the CLI and any external system authenticate against Shelve. They are managed from your account settings at [app.shelve.cloud/user/tokens](https://app.shelve.cloud/user/tokens).
+
+## How tokens are stored
+
+- The plaintext value is **shown exactly once**, at creation. Copy it immediately — Shelve never stores it and cannot retrieve it later.
+- Only the SHA-256 hash of the token is written to the database, alongside a non-secret prefix (`she_…` — the first 12 characters). The prefix is what you see in the token list and in audit logs; it is useful for identifying a token without revealing it.
+- Lookups run in constant time (`timingSafeEqual` on the hash), so there is no side channel that leaks bit-by-bit comparisons.
+
+::callout{type="info"}
+Tokens are produced from `crypto.randomBytes(32)` and encoded in [Crockford base32](https://www.crockford.com/base32.html). They are 256 bits of entropy and cannot be brute-forced.
+::
+
+## Scoped tokens
+
+By default a token inherits your account's full access. You can narrow it when creating the token:
+
+::field-group
+  ::field{name="permissions" type="('read' | 'write')[]"}
+  At least one is required. `read` grants listing and fetching, `write` grants mutations. A read-only token that tries to POST a variable receives `403 Token missing 'write' permission`.
+  ::
+
+  ::field{name="teamIds" type="number[]"}
+  Restrict the token to one or more teams. Requests targeting any other team return `403 Token not authorized for this team`.
+  ::
+
+  ::field{name="projectIds" type="number[]"}
+  Restrict the token to specific projects within the allowed teams.
+  ::
+
+  ::field{name="environmentIds" type="number[]"}
+  Restrict the token to specific environments. Useful for CI tokens that should only read `production` secrets, for example.
+  ::
+::
+
+Scope enforcement happens server-side in a dedicated middleware; the token can never outgrow the scope it was issued with.
+
+## Expiry
+
+Every token may carry an `expiresAt`. After that date the token is refused with `401 Token expired` even before it is hashed and matched. Rotating a short-lived CI token is as simple as creating a new one; no restart or config push is required.
+
+## IP allowlist
+
+Optionally attach a list of CIDR blocks to a token. Requests originating outside those blocks are rejected with `401 Token not authorized for this network`. Both IPv4 and IPv6 notations are supported.
+
+## Audit trail
+
+Token lifecycle events (`token.create`, `token.delete`) and every authenticated request surface in [audit logs](/docs/core-features/audit-logs) with the token prefix, actor, IP, and user agent. When something looks wrong, revoke the token from the UI — the hash is deleted and the next request using it returns `401`.
+
+## Sending tokens
+
+The CLI and any integration should send the token as an `Authorization: Bearer <token>` header. The legacy `Cookie: authToken=…` path still works for older CLI builds but returns `Deprecation: true` / `Sunset: Wed, 01 Jul 2026 00:00:00 GMT` response headers — migrate clients before that date.

--- a/apps/lp/content/index.yml
+++ b/apps/lp/content/index.yml
@@ -37,7 +37,7 @@ sections:
         size: xs
         icon: lucide:key-round
         variant: ghost
-      - label: BYOK ready
+      - label: Tamper-evident
         size: xs
         icon: lucide:shield
         variant: ghost
@@ -69,7 +69,7 @@ sections:
         size: xs
         icon: lucide:code
         variant: ghost
-      - label: 90-day retention
+      - label: Append-only
         size: xs
         icon: lucide:archive
         variant: ghost
@@ -154,7 +154,7 @@ faq:
   items:
     - label: Is Shelve free?
       defaultOpen: true
-      content: Yes. Shelve is **open-source** and **free** to use, including every security feature on this page — envelope encryption, scoped tokens, audit logs, and agent-safe ignore files. No paywalled tier for the core experience.
+      content: Shelve is **open source** and free to self-host. The hosted instance at `app.shelve.cloud` is currently free to use, and every security feature on this page — envelope encryption, scoped tokens, audit logs, and agent-safe ignore files — ships in the open-source core.
     - label: How does Shelve encrypt my secrets?
       content: Shelve uses a two-tier **envelope encryption** scheme. Each variable is sealed with a per-project **Data Encryption Key (DEK)** using AES-256-GCM, and the DEK itself is sealed with a platform-wide **Key Encryption Key (KEK)**. A leaked DEK compromises one project, not the whole instance. Plaintext never lands in the database. Read the full model on the [Encryption page](/docs/core-features/encryption).
     - label: How are API tokens stored?

--- a/apps/lp/content/index.yml
+++ b/apps/lp/content/index.yml
@@ -25,6 +25,70 @@ sections:
         size: xs
         icon: lucide:key
         variant: ghost
+  - id: encryption
+    title: Envelope encryption, per project
+    description: Every variable is encrypted with a per-project Data Encryption Key (DEK), itself sealed by a platform Key Encryption Key (KEK). A leaked DEK scopes the blast radius to a single project, and rotating keys never touches your application code.
+    links:
+      - label: AES-256-GCM
+        size: xs
+        icon: lucide:lock
+        variant: ghost
+      - label: Per-project DEK
+        size: xs
+        icon: lucide:key-round
+        variant: ghost
+      - label: BYOK ready
+        size: xs
+        icon: lucide:shield
+        variant: ghost
+  - id: tokens
+    title: Scoped, expiring API tokens
+    description: Stop shipping broad-power tokens. Create tokens scoped to specific teams, projects, environments, or permissions — with optional expiry and IP allowlists. Tokens are shown once, stored hashed, and every usage lands in the audit log.
+    links:
+      - label: Fine-grained scopes
+        size: xs
+        icon: lucide:filter
+        variant: ghost
+      - label: Expire automatically
+        size: xs
+        icon: lucide:timer
+        variant: ghost
+      - label: IP allowlist
+        size: xs
+        icon: lucide:network
+        variant: ghost
+  - id: audit
+    title: Audit everything that matters
+    description: Team changes, project writes, variable edits, token creations — every security-relevant action is captured with actor, IP, user agent, and resource context. Query the feed via API, filter by action, and build your own alerting on top.
+    links:
+      - label: Immutable feed
+        size: xs
+        icon: lucide:history
+        variant: ghost
+      - label: Filterable API
+        size: xs
+        icon: lucide:code
+        variant: ghost
+      - label: 90-day retention
+        size: xs
+        icon: lucide:archive
+        variant: ghost
+  - id: agent
+    title: Safe with your AI coding agent
+    description: Shelve treats AI agents as first-class citizens. `shelve init` provisions `.cursorignore`, `.aiderignore`, `.codeiumignore`, and more so your coding agent never reads a raw `.env` file. Tokens live in the OS keychain. Runtime injection keeps secrets in memory only.
+    links:
+      - label: .cursorignore
+        size: xs
+        icon: lucide:eye-off
+        variant: ghost
+      - label: OS keychain
+        size: xs
+        icon: lucide:shield
+        variant: ghost
+      - label: Zero disk writes
+        size: xs
+        icon: lucide:hard-drive-download
+        variant: ghost
   - id: env
     title: Ensure Environment Parity
     description: Stop runtime errors caused by missing variables. Shelve detects inconsistencies across your environments instantly.
@@ -90,19 +154,23 @@ faq:
   items:
     - label: Is Shelve free?
       defaultOpen: true
-      content: Yes! Shelve is **open-source** and **free** to use. We're committed to providing powerful core secrets management accessible to all developers. While we might introduce optional advanced features in the future, the core Shelve experience will always remain free.
-    - label: Is Shelve secure?
-      content: Security is fundamental to Shelve. Your secrets are hashed **(SHA-256)** for integrity and encrypted at rest using strong **AES-256 encryption**. Our open-source nature means our security practices are fully transparent and can be audited by the community directly on GitHub.
+      content: Yes. Shelve is **open-source** and **free** to use, including every security feature on this page — envelope encryption, scoped tokens, audit logs, and agent-safe ignore files. No paywalled tier for the core experience.
+    - label: How does Shelve encrypt my secrets?
+      content: Shelve uses a two-tier **envelope encryption** scheme. Each variable is sealed with a per-project **Data Encryption Key (DEK)** using AES-256-GCM, and the DEK itself is sealed with a platform-wide **Key Encryption Key (KEK)**. A leaked DEK compromises one project, not the whole instance. Plaintext never lands in the database. Read the full model on the [Encryption page](/docs/core-features/encryption).
+    - label: How are API tokens stored?
+      content: Tokens are generated from a Crockford-base32 alphabet, displayed **once**, then stored as a **SHA-256 hash** alongside a short non-secret prefix used for audit display. You can scope tokens to specific teams, projects, environments, and permissions, set an expiry, and restrict them to an IP allowlist. Details on the [Tokens page](/docs/core-features/tokens).
+    - label: Is Shelve safe to use with AI coding agents?
+      content: Yes, by design. `shelve init` writes `.cursorignore`, `.aiderignore`, `.codeiumignore`, and others so your agent never reads `.env` files or the local cache. Use `shelve run` to inject variables into the spawned process memory with zero disk writes. CLI tokens live in the **OS keychain** (Keychain, Credential Vault, libsecret), not a plaintext dotfile.
+    - label: Can I audit who did what?
+      content: Every security-relevant action (team, project, variable, token, member) is logged with actor, IP, user agent, and resource context. Query the feed via the filterable `/api/teams/:slug/audit-logs` endpoint or through the dashboard. See [Audit logs](/docs/core-features/audit-logs).
     - label: Can I self-host Shelve?
-      content: Absolutely. Shelve is designed for flexibility, including self-hosting. You can deploy your own instance of Shelve using [Vercel](/docs/self-hosting/vercel), and more providers coming soon.
+      content: Absolutely. Shelve is designed for flexibility, including self-hosting. You can deploy your own instance using [Vercel](/docs/self-hosting/vercel), and more providers are coming soon. You own the KEK, the database, and the audit trail end-to-end.
     - label: Does Shelve integrate with other tools?
-      content: Yes. Seamless integration is key to Shelve's vision. We currently offer robust synchronization with [GitHub Secrets](/docs/integrations/github), and we're actively working on expanding our integrations with more platforms and tools to further streamline your workflow.
-    - label: How can I contribute to Shelve?
-      content: We'd love your help! Shelve thrives on community contributions. Whether it's submitting PRs, reporting issues, suggesting features, or enhancing documentation, every contribution matters. Find out how to get involved in our [Contributing Guide](/docs/contributing).
+      content: Yes. Native synchronization with [GitHub Secrets](/docs/integrations/github) is available today, and `shelve run` injects variables into any CI, container, or process without writing a `.env` file. More integrations are actively in development.
     - label: Is Shelve production-ready?
-      content: Yes. Shelve is actively used and trusted in production by developers and teams. The core platform is stable and reliable, and we're committed to continuous improvement and adding value.
-    - label: How can I get support?
-      content: For technical support, you can open an issue on [GitHub](https://git.new/shelve) or reach out via email at contact@shelve.cloud.
+      content: Yes. Shelve is actively used and trusted in production by developers and teams. The core platform is stable, covered by an e2e test suite, and every release follows a changeset-based version bump.
+    - label: How can I get support or contribute?
+      content: Open an issue on [GitHub](https://git.new/shelve) or reach out via email at contact@shelve.cloud. Contributions are welcome — see the [Contributing guide](/docs/contributing) to get started.
 cta:
   dynamicTitle:
     morning: Secure your build this morning


### PR DESCRIPTION
## Summary

The landing page was still selling Shelve on "centralize your env vars" and had not caught up with the v5 release (envelope encryption, scoped API tokens, audit logs, AI-agent safety). This PR surfaces the full security story on the home page.

## New sections & components

Four new sections are inserted into \`content/index.yml\` between the existing "Secrets Management" and "Environment Parity" blocks, each wired to a new Vue component:

| Section id | Component | Message |
|---|---|---|
| \`encryption\` | \`LandingEncryption\` | Envelope scheme: KEK → DEK → ciphertext, per-project blast radius |
| \`tokens\` | \`LandingTokens\` | Scoped API tokens, expiry, IP allowlist, prefix + hidden body |
| \`audit\` | \`LandingAuditLogs\` | Mock feed with action / actor / resource entries |
| \`agent\` | \`LandingAgentSafety\` | \`.cursorignore\` shielding AI agents from \`.env\` / \`.shelve/\` |

The visual style follows the existing \`Install\`/\`Console\` patterns: \`bg-default/60 backdrop-blur-lg ring-1 ring-default\` cards with Lucide icons and small copy.

## FAQ refresh

Rewrote the FAQ to match v5:
- Envelope encryption (AES-256-GCM, per-project DEK, KEK-sealed) replaces the older "SHA-256 / AES-256" line.
- Token model: plaintext once, SHA-256 hash, Crockford base32 prefix, scopes + expiry + IP allowlist.
- New "Can I audit who did what?" entry pointing to the audit-logs page.
- New "Is Shelve safe with AI coding agents?" entry explaining \`shelve init\` + keychain + \`shelve run\`.

## Deliberately NOT changed

- The hero is untouched — per the request, \`shelve run\` is not promoted as a hero feature, just referenced where relevant.

## Test plan

- [ ] \`pnpm --filter='@shelve/lp' dev\` — scroll the home page top to bottom, check the four new sections render and alternate sides like the existing ones.
- [ ] Expand every FAQ entry, verify links resolve to \`/docs/core-features/{encryption,tokens,audit-logs}\`.
- [ ] \`pnpm --filter='@shelve/lp' build\` — confirmed green locally.