### PR TITLE
fix(changeset): retarget LP changesets to @shelve/lp

### DIFF
--- a/.changeset/lp-v5-features.md
+++ b/.changeset/lp-v5-features.md
@@ -1,5 +1,5 @@
 ---
-"shelve": patch
+"@shelve/lp": patch
 ---
 
 Landing page: showcase the v5 security surface — new sections for envelope encryption, scoped API tokens, audit logs, and AI-agent safety, each with a dedicated visual component. Refresh the FAQ to reflect the new encryption model, token hashing, and agent-safety workflow.

--- a/.changeset/quiet-lizards-give.md
+++ b/.changeset/quiet-lizards-give.md
@@ -1,5 +1,5 @@
 ---
-"shelve": patch
+"@shelve/lp": patch
 ---
 
 Docs: refresh the landing-page documentation to cover v5 features — envelope encryption (KEK/DEK), scoped API tokens, audit logs, and AI-agent safety from `shelve init`. Update CLI pages (`init`, `run`, `login`/`logout`) to reflect OS-keychain storage, encrypted offline cache, and the `.env.template` secret-reference syntax.


### PR DESCRIPTION
## Summary

The release workflow has been failing on every push to \`main\` since v5 with:

\`\`\`
🦋 error Found changeset lp-v5-features for package shelve which is not in the workspace
\`\`\`

Two changesets (\`lp-v5-features.md\` and \`quiet-lizards-give.md\`) still target a package literally named \`"shelve"\`, which doesn't exist anymore — during the v5 split the app was renamed \`@shelve/app\` and the landing page \`@shelve/lp\`. \`@changesets/assemble-release-plan\` errors out before it can build a release plan, so changeset PR creation never runs.

Both changesets are about landing-page content / docs, so they belong to \`@shelve/lp\`.

Verified locally: \`pnpm exec changeset status\` and \`pnpm run version\` both get past assemble-release-plan after the fix (the only remaining local error is a missing \`GITHUB_TOKEN\` for changelog generation, which is provided in CI).

## Test plan

- [ ] CI for this PR is green.
- [ ] After merge, the \`release\` workflow run on the merge commit succeeds and either opens / updates the \`changeset-release/main\` PR.