### PR TITLE
chore(changeset): drop no-op LP changesets

### DIFF
--- a/.changeset/lp-v5-features.md
+++ b/.changeset/lp-v5-features.md
@@ -1,5 +1,0 @@
----
-"@shelve/lp": patch
----
-
-Landing page: showcase the v5 security surface — new sections for envelope encryption, scoped API tokens, audit logs, and AI-agent safety, each with a dedicated visual component. Refresh the FAQ to reflect the new encryption model, token hashing, and agent-safety workflow.

--- a/.changeset/quiet-lizards-give.md
+++ b/.changeset/quiet-lizards-give.md
@@ -1,5 +1,0 @@
----
-"@shelve/lp": patch
----
-
-Docs: refresh the landing-page documentation to cover v5 features — envelope encryption (KEK/DEK), scoped API tokens, audit logs, and AI-agent safety from `shelve init`. Update CLI pages (`init`, `run`, `login`/`logout`) to reflect OS-keychain storage, encrypted offline cache, and the `.env.template` secret-reference syntax.


### PR DESCRIPTION
## Summary

Follow-up to #740. The release workflow still fails after that fix, this time on PR creation:

\`\`\`
Error: HttpError: Validation Failed: ... "No commits between main and changeset-release/main"
\`\`\`

### Root cause

\`@shelve/lp\` is **content-only** and has no \`version\` field in its \`package.json\` — Changesets silently skips it. The two remaining changesets (\`lp-v5-features.md\`, \`quiet-lizards-give.md\`) were the only ones left after #741 consumed \`token-ui-restrictions\`, and both targeted \`@shelve/lp\`. Result:

- \`changeset status\` → "NO packages to be bumped"
- \`changeset version\` → "All files have been updated" but \`git status\` is clean
- The release action then pushes an empty branch and tries to open a PR → 422.

### Fix

Just delete the two no-op changesets. Their content already shipped via #737 (docs) and #738 (LP). Once a real bump shows up again the workflow will be unblocked.

### Verified locally

\`\`\`
$ pnpm exec changeset status
🦋 info NO packages to be bumped at patch
🦋 info NO packages to be bumped at minor
🦋 info NO packages to be bumped at major
\`\`\`

So after merge the release action will simply have nothing to do (the changesets/action step exits without trying to push), which is the correct steady state.

## Followup

Worth considering longer-term: drop the LP from changeset's awareness entirely (either give it a \`version\` so it can actually be bumped, or add it to the \`ignore\` list in \`.changeset/config.json\`) so we don't fall in this trap again. Happy to do it in a follow-up.

## Test plan

- [ ] Release workflow run on the merge commit completes without error.