### PR TITLE
chore: upgrade pnpm to v11 and add minimumReleaseAge

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,9 +18,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
-          version: latest
           run_install: false
 
       - name: 📦 Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
-          version: latest
           run_install: false
 
       - name: 📦 Install dependencies

--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -32,9 +32,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
-          version: latest
           run_install: true
 
       - name: 🛠️ Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,7 @@ jobs:
           node-version: "22.22.2"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: latest
+      - uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
-          version: latest
           run_install: false
 
       - name: Setup Node.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-shamefully-hoist=true
-auto-install-peers=true
-ignore-workspace-root-check=true

--- a/package.json
+++ b/package.json
@@ -37,21 +37,7 @@
     "turbo": "^2.9.6",
     "typescript": "^5.9.3"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "sharp"
-    ],
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "vue-demi"
-    ],
-    "overrides": {
-      "nuxt-og-image": "6.4.8"
-    }
-  },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.1.3",
   "workspaces": [
     "packages/*",
     "apps/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ allowBuilds:
   '@parcel/watcher': false
   esbuild: false
   vue-demi: false
+  unrs-resolver: false
   better-sqlite3: true
   sharp: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,16 @@ allowBuilds:
 
 overrides:
   nuxt-og-image: 6.4.8
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  # Nuxt
+  - '@nuxt/*'
+  - '@nuxtjs/*'
+  - 'nuxt'
+  - 'nuxt-*'
+  # Vercel
+  - '@vercel/*'
+  - '@ai-sdk/*'
+  - 'ai'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,16 @@ packages:
   - 'packages/*'
   - 'apps/*'
 
-onlyBuiltDependencies:
-  - better-sqlite3
+shamefullyHoist: true
+autoInstallPeers: true
+ignoreWorkspaceRootCheck: true
+
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  vue-demi: false
+  better-sqlite3: true
+  sharp: true
+
+overrides:
+  nuxt-og-image: 6.4.8


### PR DESCRIPTION
## Summary

Two related changes to harden the supply chain and modernize the package manager setup.

### 1. Upgrade pnpm to v11

- Bump `packageManager` to `pnpm@11.1.3`
- Bump `pnpm/action-setup@v2` → `@v6` in workflows (so action reads `packageManager`)
- Migrate `onlyBuiltDependencies` + `ignoredBuiltDependencies` → unified `allowBuilds` map (required in v11)
- Move `overrides` from `package.json` → `pnpm-workspace.yaml` (the `pnpm` field in `package.json` is no longer recognized in v11)
- Move `shamefullyHoist`, `autoInstallPeers`, `ignoreWorkspaceRootCheck` from `.npmrc` → `pnpm-workspace.yaml` (in v11, `.npmrc` only holds auth/registry)
- Delete `.npmrc` (now empty)

### 2. Add `minimumReleaseAge` to harden supply chain

Sets a 2-day minimum age (2880 minutes) before any newly published dependency can resolve. Mitigates compromised-package attacks where a malicious version is pushed and pulled into installs within hours.

Trusted-source allowlist exempts the Nuxt and Vercel ecosystems:
- `@nuxt/*`, `@nuxtjs/*`, `nuxt`, `nuxt-*`
- `@vercel/*`, `@ai-sdk/*`, `ai`

## Test plan
- [ ] `pnpm install` resolves cleanly with v11 (lockfile already verified via `--lockfile-only`, 1909 entries pass supply-chain policies)
- [ ] CI passes: test.yml, build.yml, autofix.yml
- [ ] `pnpm run build:cli` continues to work for continuous-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded pnpm to a newer major version in project config.
  * Updated CI workflows to use the latest pnpm setup action.
  * Removed legacy registry/client settings and reorganized workspace/package dependency and build configuration (adjusted hoisting, peer install behavior, build allowlist/overrides, and release timing controls).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/shelve/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->