### PR TITLE
fix(cli): improve run, debug flag, and error output

### DIFF
--- a/.changeset/run-script-shorthand.md
+++ b/.changeset/run-script-shorthand.md
@@ -1,0 +1,5 @@
+---
+"@shelve/cli": patch
+---
+
+Fix `shelve run dev` script resolution, add `--debug` / `SHELVE_DEBUG`, and clean up CLI error output so spinner failures no longer overlap with error messages.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "unbuild",
     "stub": "unbuild --stub",
-    "dev": "DEBUG=true bun src/index.ts",
+    "dev": "SHELVE_DEBUG=1 bun src/index.ts",
     "dev:prod": "NODE_ENV=production bun src/index.ts",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
@@ -61,6 +61,7 @@
     "tree-kill": "^1.2.2"
   },
   "devDependencies": {
+    "@types/node": "^22.15.0",
     "@types/npm-registry-fetch": "^8.0.9",
     "@types/semver": "^7.7.1",
     "unbuild": "^3.6.1",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -6,6 +6,8 @@ import { defineCommand } from 'citty'
 import { intro, log } from '@clack/prompts'
 import type { EnvVarExport, Project, Environment } from '@types'
 import consola from 'consola'
+import { readPackageJSON } from 'pkg-types'
+import { runScript } from 'nypm'
 import {
   handleCancel,
   loadShelveConfig,
@@ -21,8 +23,6 @@ import {
   ProjectService,
   type CacheKeyInput,
 } from '../services'
-import { readPackageJSON } from 'pkg-types'
-import { runScript } from 'nypm'
 import { debugLog } from '../constants'
 
 const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -21,7 +21,9 @@ import {
   ProjectService,
   type CacheKeyInput,
 } from '../services'
-import { DEBUG } from '../constants'
+import { readPackageJSON } from 'pkg-types'
+import { runScript } from 'nypm'
+import { debugLog } from '../constants'
 
 const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const WATCH_POLL_MS = 5_000
@@ -124,9 +126,13 @@ export default defineCommand({
         })
         if (!noCache && token) CacheService.write(cacheInput(envName), token, variables)
       } catch (err) {
-        if (noCache) throw err
+        if (noCache) {
+          process.exit(1)
+        }
         const cached = token ? CacheService.read(cacheInput(envName), token, cacheTtl) : null
-        if (!cached) throw err
+        if (!cached) {
+          process.exit(1)
+        }
         log.warn('Failed to fetch from Shelve; falling back to encrypted cache.')
         variables = cached
       }
@@ -134,7 +140,7 @@ export default defineCommand({
 
     const secretEnv = buildEnv(variables, template, envName)
 
-    let child = spawnChild(argv, secretEnv)
+    let child = await spawnChild(argv, secretEnv)
 
     if (runArgs.watch) {
       if (!projectData || !environment) {
@@ -152,8 +158,8 @@ export default defineCommand({
           template,
           restartOnChange: runArgs.restartOnChange === true,
           getChild: () => child,
-          spawnNew: (env) => {
-            child = spawnChild(argv, env)
+          spawnNew: async (env) => {
+            child = await spawnChild(argv, env)
             return child
           },
         })
@@ -219,8 +225,25 @@ function resolveCommand(argv: string[]): { bin: string; argv: string[] } {
   return { bin: argv[0]!, argv: argv.slice(1) }
 }
 
-function spawnChild(rawArgv: string[], env: NodeJS.ProcessEnv): ChildProcess {
-  const { bin, argv } = resolveCommand(rawArgv)
+async function resolveCommandWithScripts(argv: string[]): Promise<{ bin: string; argv: string[] }> {
+  if (argv.length === 1 && !argv[0]!.includes('/') && !argv[0]!.includes(' ')) {
+    const script = argv[0]!
+    const pkg = await readPackageJSON().catch(() => null)
+    if (pkg?.scripts?.[script]) {
+      const result = await runScript(script, { cwd: process.cwd(), dry: true })
+      if (result.exec) {
+        debugLog(`Resolved script "${script}" → ${result.exec.command} ${result.exec.args.join(' ')}`)
+        return { bin: result.exec.command, argv: result.exec.args }
+      }
+    }
+  }
+
+  return resolveCommand(argv)
+}
+
+async function spawnChild(rawArgv: string[], env: NodeJS.ProcessEnv): Promise<ChildProcess> {
+  const { bin, argv } = await resolveCommandWithScripts(rawArgv)
+  debugLog(`Spawning: ${bin} ${argv.join(' ')}`)
   const isWindows = process.platform === 'win32'
 
   const child = spawn(bin, argv, {
@@ -231,7 +254,10 @@ function spawnChild(rawArgv: string[], env: NodeJS.ProcessEnv): ChildProcess {
   })
 
   if (typeof child.pid !== 'number') {
-    consola.error('Failed to start child process')
+    const hint = rawArgv.length === 1
+      ? `Try \`shelve run -- pnpm ${rawArgv[0]}\` or ensure the command is on your PATH.`
+      : `Try \`shelve run -- ${rawArgv.join(' ')}\`.`
+    consola.error(`Failed to start child process "${bin}". ${hint}`)
     process.exit(1)
   }
 
@@ -241,14 +267,14 @@ function spawnChild(rawArgv: string[], env: NodeJS.ProcessEnv): ChildProcess {
 
 function attachLifecycle(child: ChildProcess, isWindows: boolean): void {
   let shuttingDown = false
-  let killTimer: NodeJS.Timeout | null = null
+  let killTimer: ReturnType<typeof setTimeout> | null = null
 
   const killGroup = (signal: NodeJS.Signals): void => {
     try {
       if (isWindows) child.kill(signal)
       else if (typeof child.pid === 'number') process.kill(-child.pid, signal)
     } catch (err) {
-      if (DEBUG) consola.warn(`kill(${signal}) failed: ${err}`)
+      debugLog(`kill(${signal}) failed`, err)
     }
   }
 
@@ -258,7 +284,7 @@ function attachLifecycle(child: ChildProcess, isWindows: boolean): void {
       process.exit(130)
     }
     shuttingDown = true
-    if (DEBUG) consola.info(`Received ${signal}, forwarding to child...`)
+    debugLog(`Received ${signal}, forwarding to child`)
     killGroup(signal)
     killTimer = setTimeout(() => {
       consola.warn('Child did not exit after 5s, sending SIGKILL')
@@ -298,7 +324,7 @@ type WatchOpts = {
   template: ParsedTemplate | null
   restartOnChange: boolean
   getChild: () => ChildProcess
-  spawnNew: (env: NodeJS.ProcessEnv) => ChildProcess
+  spawnNew: (env: NodeJS.ProcessEnv) => ChildProcess | Promise<ChildProcess>
 }
 
 function fingerprint(variables: EnvVarExport[]): string {
@@ -337,20 +363,20 @@ function startWatch(opts: WatchOpts): void {
           } else {
             child.kill('SIGTERM')
           }
-          opts.spawnNew(env)
+          await opts.spawnNew(env)
         } else {
           const child = opts.getChild()
           try {
             if (child.pid && process.platform !== 'win32') process.kill(-child.pid, 'SIGHUP')
             else child.kill('SIGHUP')
           } catch (err) {
-            if (DEBUG) consola.warn(`Failed to send SIGHUP: ${err}`)
+            debugLog('Failed to send SIGHUP', err)
           }
         }
       }
       lastPrint = fp
     } catch (err) {
-      if (DEBUG) consola.warn(`Watch poll failed: ${err}`)
+      debugLog('Watch poll failed', err)
     } finally {
       inFlight = false
     }

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,2 +1,3 @@
-export const DEBUG = process.env.DEBUG === 'true'
+export { debugLog, initDebugFromArgv, isDebug, setDebug } from './utils/debug'
+
 export const DEFAULT_ENV_FILENAME = '.env'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineCommand, runMain } from 'citty'
 import consola from 'consola'
+import { initDebugFromArgv, setDebug } from './constants'
 import push from './commands/push'
 import pull from './commands/pull'
 import config from './commands/config'
@@ -16,6 +17,8 @@ import logout from './commands/logout'
 import upgrade from './commands/upgrade'
 import run from './commands/run'
 import init from './commands/init'
+
+initDebugFromArgv()
 
 function getCliPackageVersion(): string {
   try {
@@ -32,6 +35,16 @@ const main = defineCommand({
     name: 'shelve',
     description: 'Shelve CLI',
     version: getCliPackageVersion(),
+  },
+  args: {
+    debug: {
+      type: 'boolean',
+      description: 'Enable verbose debug logging (or set SHELVE_DEBUG=1)',
+      default: false,
+    },
+  },
+  setup({ args }) {
+    if (args.debug) setDebug(true)
   },
   subCommands: {
     run,

--- a/packages/cli/src/services/api-error.ts
+++ b/packages/cli/src/services/api-error.ts
@@ -1,0 +1,32 @@
+export class ShelveApiError extends Error {
+
+  readonly status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'ShelveApiError'
+    this.status = status
+  }
+
+}
+
+export function getHttpStatus(error: unknown): number | undefined {
+  if (error instanceof ShelveApiError) return error.status
+  if (error && typeof error === 'object') {
+    const e = error as { status?: number, statusCode?: number, response?: { status?: number } }
+    return e.status ?? e.statusCode ?? e.response?.status
+  }
+  return undefined
+}
+
+export function formatCliError(error: unknown, context?: string): string {
+  if (error instanceof ShelveApiError) return error.message
+  if (error instanceof Error && error.message) return error.message
+  if (context) return `${context} failed`
+  return 'Something went wrong'
+}
+
+export function isRecoverableHttpError(error: unknown, statuses: number[]): boolean {
+  const status = getHttpStatus(error)
+  return status !== undefined && statuses.includes(status)
+}

--- a/packages/cli/src/services/base.ts
+++ b/packages/cli/src/services/base.ts
@@ -5,8 +5,13 @@ import { ofetch, type $Fetch, type FetchOptions } from 'ofetch'
 import { spinner } from '@clack/prompts'
 import type { User } from '@types'
 import { askPassword, loadShelveConfig } from '../utils'
+import { formatCliError } from './api-error'
 import { ErrorService } from './error'
 import { CredentialsService } from './credentials'
+
+type LoadingOptions = {
+  recoverable?: (error: unknown) => boolean
+}
 
 export abstract class BaseService {
 
@@ -14,7 +19,8 @@ export abstract class BaseService {
 
   protected static async withLoading<T>(
     message: string,
-    callback: () => Promise<T>
+    callback: () => Promise<T>,
+    options?: LoadingOptions,
   ): Promise<T> {
     const s = spinner()
     try {
@@ -23,13 +29,18 @@ export abstract class BaseService {
       s.stop(message)
       return result
     } catch (error) {
-      s.stop(`Failed: ${message.toLowerCase()}.`)
+      if (options?.recoverable?.(error)) {
+        s.stop(message)
+        throw error
+      }
+
+      s.cancel(formatCliError(error, message))
       throw error
     }
   }
 
   static whoAmI(url: string, token: string): Promise<User> {
-    return this.withLoading('Fetching user data', () => {
+    return this.withLoading('Fetch user profile', () => {
       return ofetch(`${url}/api/user/me`, {
         method: 'GET',
         headers: {

--- a/packages/cli/src/services/cache.ts
+++ b/packages/cli/src/services/cache.ts
@@ -3,8 +3,7 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync, statSync, chmodSync
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import type { EnvVarExport } from '@types'
-import consola from 'consola'
-import { DEBUG } from '../constants'
+import { isDebug, debugLog } from '../constants'
 
 const CACHE_DIR = join(homedir(), '.shelve', 'cache')
 const CACHE_VERSION = 1
@@ -37,7 +36,7 @@ function chmod600(path: string): void {
   try {
     chmodSync(path, 0o600)
   } catch (err) {
-    if (DEBUG) consola.warn(`Failed to chmod 600 ${path}: ${err}`)
+    if (isDebug()) debugLog(`Failed to chmod 600 ${path}`, err)
   }
 }
 
@@ -79,7 +78,7 @@ export class CacheService {
       renameSync(tmp, file)
       chmod600(file)
     } catch (err) {
-      if (DEBUG) consola.warn(`Failed to write cache: ${err}`)
+      if (isDebug()) debugLog('Failed to write cache', err)
     }
   }
 
@@ -111,7 +110,7 @@ export class CacheService {
       if (payload.v !== CACHE_VERSION) return null
       return payload.variables
     } catch (err) {
-      if (DEBUG) consola.warn(`Cache read failed (will refetch): ${err}`)
+      if (isDebug()) debugLog('Cache read failed (will refetch)', err)
       return null
     }
   }

--- a/packages/cli/src/services/credentials.ts
+++ b/packages/cli/src/services/credentials.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { readUserConfig, writeUserConfig } from 'rc9'
 import consola from 'consola'
-import { DEBUG } from '../constants'
+import { isDebug, debugLog } from '../constants'
 
 const KEYRING_SERVICE = 'shelve-cli'
 const RC_FILENAME = '.shelve'
@@ -32,7 +32,7 @@ async function loadKeyring(): Promise<((service: string, account: string) => Key
     const mod = await import('@napi-rs/keyring')
     keyringFactory = (service: string, account: string): KeyringEntry => new mod.Entry(service, account) as unknown as KeyringEntry
   } catch (err) {
-    if (DEBUG) consola.warn(`Keyring unavailable, falling back to file storage: ${err}`)
+    if (isDebug()) debugLog('Keyring unavailable, falling back to file storage', err)
     keyringFactory = null
   }
   return keyringFactory
@@ -55,7 +55,7 @@ function chmod600(path: string): void {
   try {
     chmodSync(path, 0o600)
   } catch (err) {
-    if (DEBUG) consola.warn(`Failed to chmod 600 ${path}: ${err}`)
+    if (isDebug()) debugLog(`Failed to chmod 600 ${path}`, err)
   }
 }
 
@@ -91,7 +91,7 @@ function migrateLegacyConfig(): void {
     chmod600(configPath())
     unlinkSync(LEGACY_RC_PATH)
   } catch (err) {
-    if (DEBUG) consola.warn(`Legacy ~/.shelve migration skipped: ${err}`)
+    if (isDebug()) debugLog('Legacy ~/.shelve migration skipped', err)
   }
 }
 
@@ -125,7 +125,7 @@ export class CredentialsService {
         chmod600(configPath())
         return
       } catch (err) {
-        if (DEBUG) consola.warn(`Keyring write failed, falling back to file: ${err}`)
+        if (isDebug()) debugLog('Keyring write failed, falling back to file', err)
       }
     }
 
@@ -147,7 +147,7 @@ export class CredentialsService {
           const pwd = entry.getPassword()
           if (pwd) return pwd
         } catch (err) {
-          if (DEBUG) consola.warn(`Keyring read failed: ${err}`)
+          if (isDebug()) debugLog('Keyring read failed', err)
         }
       }
     }

--- a/packages/cli/src/services/env.ts
+++ b/packages/cli/src/services/env.ts
@@ -95,7 +95,7 @@ export class EnvService extends BaseService {
 
   static getEnvVariables(input: GetEnvVariables): Promise<EnvVarExport[]> {
     const { project, environmentId, slug } = input
-    return this.withLoading('Fetching variables', () => {
+    return this.withLoading('Fetch variables', () => {
       return this.request<EnvVarExport[]>(`/teams/${slug}/projects/${project.id}/variables/env/${environmentId}`)
     })
   }

--- a/packages/cli/src/services/environment.ts
+++ b/packages/cli/src/services/environment.ts
@@ -6,7 +6,7 @@ import { BaseService } from './base'
 export class EnvironmentService extends BaseService {
 
   static async promptEnvironment(slug: string): Promise<Environment> {
-    const environments = await this.withLoading('Fetching environments', async () => {
+    const environments = await this.withLoading('Fetch environments', async () => {
       return await this.request<Environment[]>(`/teams/${slug}/environments`)
     })
 
@@ -25,7 +25,7 @@ export class EnvironmentService extends BaseService {
 
   static async getEnvironment(slug: string, name?: string): Promise<Environment> {
     if (name) {
-      return await this.withLoading('Fetching environment', async () => {
+      return await this.withLoading(`Fetch environment ${name}`, async () => {
         return await this.request<Environment>(`/teams/${ slug }/environments/${ name }`)
       })
     }

--- a/packages/cli/src/services/error.ts
+++ b/packages/cli/src/services/error.ts
@@ -1,19 +1,25 @@
-import { cancel } from '@clack/prompts'
-import { DEBUG } from '../constants'
+import { debugLog, isDebug } from '../constants'
+import { ShelveApiError } from './api-error'
+
+const ERROR_MESSAGES: Record<number, string> = {
+  401: 'Authentication failed — run `shelve login` or check your token',
+  403: 'Access denied — your token cannot access this resource',
+  404: 'Not found — check your team slug and project name in shelve.json',
+  500: 'Shelve server error — try again later',
+}
 
 export class ErrorService {
 
-  static handleApiError = (ctx: any): void => {
-    const errorMap: Record<number, string> = {
-      401: 'Authentication failed, please verify your token',
-      500: 'Internal server error, please try again later',
+  static handleApiError = (ctx: { response: Response }): void => {
+    const status = ctx.response.status
+    const message = ERROR_MESSAGES[status]
+      ?? (ctx.response.statusText || `Request failed (${status})`)
+
+    if (isDebug()) {
+      debugLog('API error', { status, url: ctx.response.url })
     }
 
-    const message = errorMap[ctx.response.status] || ctx.response.statusText
-
-    if (DEBUG) console.error(ctx)
-
-    cancel(message)
+    throw new ShelveApiError(message, status)
   }
 
 }

--- a/packages/cli/src/services/error.ts
+++ b/packages/cli/src/services/error.ts
@@ -11,7 +11,7 @@ const ERROR_MESSAGES: Record<number, string> = {
 export class ErrorService {
 
   static handleApiError = (ctx: { response: Response }): void => {
-    const status = ctx.response.status
+    const { status } = ctx.response
     const message = ERROR_MESSAGES[status]
       ?? (ctx.response.statusText || `Request failed (${status})`)
 

--- a/packages/cli/src/services/project.ts
+++ b/packages/cli/src/services/project.ts
@@ -1,14 +1,15 @@
 import { type PackageJson, readPackageJSON } from 'pkg-types'
 import { log } from '@clack/prompts'
 import type { Project } from '@types'
-import { DEBUG } from '../constants'
+import { isDebug, debugLog } from '../constants'
 import { askBoolean, capitalize, handleCancel } from '../utils'
+import { isRecoverableHttpError } from './api-error'
 import { BaseService } from './base'
 
 export class ProjectService extends BaseService {
 
   static getProjects(slug: string): Promise<Project[]> {
-    return this.withLoading('Loading projects', () =>
+    return this.withLoading('Load projects', () =>
       this.request<Project[]>(`/teams/${slug}/projects`)
     )
   }
@@ -17,13 +18,15 @@ export class ProjectService extends BaseService {
     const encodedName = encodeURIComponent(name)
 
     try {
-      return await this.withLoading(`Fetching '${name}' project${DEBUG ? ' - Debug mode' : ''}`, () => {
+      return await this.withLoading(`Fetch project ${name}`, () => {
         return this.request<Project>(`/teams/${slug}/projects/name/${encodedName}`)
+      }, {
+        recoverable: error => isRecoverableHttpError(error, [400]),
       })
-    } catch (error: any) {
-      if (DEBUG) console.log(error)
+    } catch (error: unknown) {
+      if (isDebug()) debugLog(`Failed to fetch project '${name}'`, error)
 
-      if (error.statusCode === 400) {
+      if (isRecoverableHttpError(error, [400])) {
         if (autoCreate) {
           if (!name || !slug)
             return handleCancel(`Project '${name}' does not exist, and could not be auto-created without a name and slug`)
@@ -35,7 +38,7 @@ export class ProjectService extends BaseService {
         return this.createProject(name, slug, autoCreate)
       }
 
-      return handleCancel('Failed to fetch project')
+      process.exit(1)
     }
   }
 
@@ -55,7 +58,7 @@ export class ProjectService extends BaseService {
       homepage: pkg.homepage,
       repository: this.getRepositoryURL(pkg)
     }
-    return this.withLoading(`Creating '${ name }' project`, () => {
+    return this.withLoading(`Create project ${name}`, () => {
       return this.request<Project>(`/teams/${ slug }/projects`, {
         method: 'POST',
         body: input

--- a/packages/cli/src/utils/debug.ts
+++ b/packages/cli/src/utils/debug.ts
@@ -1,0 +1,26 @@
+import consola from 'consola'
+
+let debugEnabled
+  = process.env.DEBUG === 'true'
+    || process.env.SHELVE_DEBUG === '1'
+    || process.env.SHELVE_DEBUG === 'true'
+
+export function isDebug(): boolean {
+  return debugEnabled
+}
+
+export function setDebug(enabled: boolean): void {
+  debugEnabled = enabled
+}
+
+export function initDebugFromArgv(argv: string[] = process.argv): void {
+  if (argv.includes('--debug')) {
+    setDebug(true)
+  }
+}
+
+export function debugLog(message: string, detail?: unknown): void {
+  if (!isDebug()) return
+  if (detail === undefined) consola.debug(message)
+  else consola.debug(message, detail)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 0.5.0(vue@3.5.33(typescript@5.9.3))
       '@nuxtjs/seo':
         specifier: ^5.1.3
-        version: 5.1.3(8158a09ea64a0a84cdae1bd7146a5419)
+        version: 5.1.3(1d7f501d26f970d5377e48ab315bf886)
       '@shelve/base':
         specifier: workspace:*
         version: link:../base
@@ -127,7 +127,7 @@ importers:
         version: 12.9.0
       docus:
         specifier: ^5.10.0
-        version: 5.10.0(ee44486cc9cce13b53ac37d05ffe55cc)
+        version: 5.10.0(b0c20b4919a47b742c5cfd85214d64fb)
       nuxt-build-cache:
         specifier: ^0.1.1
         version: 0.1.1(magicast@0.5.2)
@@ -201,7 +201,7 @@ importers:
         version: 3.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
       '@nuxt/test-utils':
         specifier: ^4.0.2
-        version: 4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(playwright-core@1.59.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       '@shelve/cli':
         specifier: workspace:*
         version: link:../../packages/cli
@@ -229,7 +229,7 @@ importers:
     devDependencies:
       '@nuxt/test-utils':
         specifier: ^4.0.2
-        version: 4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(playwright-core@1.59.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -291,6 +291,9 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
     devDependencies:
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.19
       '@types/npm-registry-fetch':
         specifier: ^8.0.9
         version: 8.0.9
@@ -302,7 +305,7 @@ importers:
         version: 3.6.1(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -2844,90 +2847,6 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@resvg/resvg-js-android-arm-eabi@2.6.2':
-    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [android]
-
-  '@resvg/resvg-js-android-arm64@2.6.2':
-    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@resvg/resvg-js-darwin-arm64@2.6.2':
-    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@resvg/resvg-js-darwin-x64@2.6.2':
-    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
-    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
-    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
-    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
-    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@resvg/resvg-js-linux-x64-musl@2.6.2':
-    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
-    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
-    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
-    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@resvg/resvg-js@2.6.2':
-    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
-    engines: {node: '>= 10'}
-
-  '@resvg/resvg-wasm@2.6.2':
-    resolution: {integrity: sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==}
-    engines: {node: '>= 10'}
-
   '@rolldown/binding-android-arm64@1.0.0-beta.57':
     resolution: {integrity: sha512-GoOVDy8bjw9z1K30Oo803nSzXJS/vWhFijFsW3kzvZCO8IZwFnNa6pGctmbbJstKl3Fv6UBwyjJQN6msejW0IQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3417,11 +3336,6 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
-
-  '@shuding/opentype.js@1.4.0-beta.0':
-    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
-    engines: {node: '>= 8.0.0'}
-    hasBin: true
 
   '@simple-git/args-pathspec@1.0.3':
     resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
@@ -3928,6 +3842,9 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -4029,6 +3946,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/addons@2.1.13':
     resolution: {integrity: sha512-xiM5ERU68FEuiBCCiPZ1EDkja+kH4hKKot/7dNJufneACtGoAFWnKUcmj/iB9BKjVwgBBF3sFYO3qXjkNFXWxA==}
@@ -4768,10 +4686,6 @@ packages:
   bare-url@2.4.0:
     resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
-  base64-js@0.0.8:
-    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
-    engines: {node: '>= 0.4'}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4895,9 +4809,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -5105,31 +5016,14 @@ packages:
       srvx:
         optional: true
 
-  css-background-parser@0.1.0:
-    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
-
-  css-box-shadow@1.0.0-3:
-    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
-
-  css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
-    engines: {node: '>=4'}
-
   css-declaration-sorter@7.4.0:
     resolution: {integrity: sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
 
-  css-gradient-parser@0.0.17:
-    resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
-    engines: {node: '>=16'}
-
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
-
-  css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -5526,10 +5420,6 @@ packages:
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
-  emoji-regex-xs@2.0.1:
-    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
-    engines: {node: '>=10.0.0'}
-
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -5907,9 +5797,6 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
-
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -6234,10 +6121,6 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
-
-  hex-rgb@4.3.0:
-    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
-    engines: {node: '>=6'}
 
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
@@ -6731,9 +6614,6 @@ packages:
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
-
-  linebreak@1.1.0:
-    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
@@ -7588,18 +7468,12 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
-  pako@0.2.9:
-    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
-
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
-
-  parse-css-color@0.2.1:
-    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -7711,11 +7585,6 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
-
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -8266,10 +8135,6 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  satori@0.19.3:
-    resolution: {integrity: sha512-dKr8TNYSyceWqBoTHWntjy25xaiWMw5GF+f8QOqFsov9OpTswLs7xdbvZudGRp9jkzbhv/4mVjVZYFtpruGKiA==}
-    engines: {node: '>=16'}
-
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -8560,9 +8425,6 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
-
-  string.prototype.codepointat@0.2.1:
-    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -8863,6 +8725,9 @@ packages:
   unctx@2.5.0:
     resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
@@ -8875,9 +8740,6 @@ packages:
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
-
-  unicode-trie@2.0.0:
-    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -9074,6 +8936,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.3.1:
@@ -9516,9 +9379,6 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
-
-  yoga-layout@3.2.1:
-    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -11360,7 +11220,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(playwright-core@1.59.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@nuxt/test-utils@4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -11389,10 +11249,9 @@ snapshots:
       tinyexec: 1.1.1
       ufo: 1.6.3
       unplugin: 3.0.0
-      vitest-environment-nuxt: 2.0.0(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(playwright-core@1.59.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+      vitest-environment-nuxt: 2.0.0(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       vue: 3.5.33(typescript@5.9.3)
     optionalDependencies:
-      playwright-core: 1.59.1
       vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - crossws
@@ -11967,14 +11826,14 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.1.3(8158a09ea64a0a84cdae1bd7146a5419)':
+  '@nuxtjs/seo@5.1.3(1d7f501d26f970d5377e48ab315bf886)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(817853b61f98a69df6ddde0c23e29360))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(zod@4.3.6)
       '@nuxtjs/sitemap': 8.0.12(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(817853b61f98a69df6ddde0c23e29360))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(zod@4.3.6)
       nuxt: 4.4.2(817853b61f98a69df6ddde0c23e29360)
       nuxt-link-checker: 5.0.9(@nuxt/schema@4.4.2)(@upstash/redis@1.37.0)(db0@0.3.4(@electric-sql/pglite@0.4.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260413.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(817853b61f98a69df6ddde0c23e29360))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(zod@4.3.6)
-      nuxt-og-image: 6.4.8(cba6cfc151a7d083c92ea9c04b33f740)
+      nuxt-og-image: 6.4.8(d9231ed88b8bf12d212bd575343ab704)
       nuxt-schema-org: 6.0.4(fc69a991fbc88346cffadd0cf8ab6edd)
       nuxt-seo-utils: 8.1.7(@nuxt/schema@4.4.2)(esbuild@0.27.7)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(817853b61f98a69df6ddde0c23e29360))(rolldown@1.0.0-rc.15)(rollup@4.60.1)(unhead@2.1.13)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(zod@4.3.6)
       nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(817853b61f98a69df6ddde0c23e29360))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))(zod@4.3.6)
@@ -12588,61 +12447,6 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@resvg/resvg-js-android-arm-eabi@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-android-arm64@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-darwin-arm64@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-darwin-x64@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-linux-x64-musl@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
-    optional: true
-
-  '@resvg/resvg-js@2.6.2':
-    optionalDependencies:
-      '@resvg/resvg-js-android-arm-eabi': 2.6.2
-      '@resvg/resvg-js-android-arm64': 2.6.2
-      '@resvg/resvg-js-darwin-arm64': 2.6.2
-      '@resvg/resvg-js-darwin-x64': 2.6.2
-      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
-      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
-      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
-      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
-      '@resvg/resvg-js-linux-x64-musl': 2.6.2
-      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
-      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
-      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
-    optional: true
-
-  '@resvg/resvg-wasm@2.6.2':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-beta.57':
     optional: true
 
@@ -13002,12 +12806,6 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
-
-  '@shuding/opentype.js@1.4.0-beta.0':
-    dependencies:
-      fflate: 0.7.4
-      string.prototype.codepointat: 0.2.1
-    optional: true
 
   '@simple-git/args-pathspec@1.0.3': {}
 
@@ -13456,6 +13254,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -13737,6 +13539,14 @@ snapshots:
       '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -14330,9 +14140,6 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
-  base64-js@0.0.8:
-    optional: true
-
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.18: {}
@@ -14477,9 +14284,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
-
-  camelize@1.0.1:
-    optional: true
 
   caniuse-api@3.0.0:
     dependencies:
@@ -14651,21 +14455,9 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.15
 
-  css-background-parser@0.1.0:
-    optional: true
-
-  css-box-shadow@1.0.0-3:
-    optional: true
-
-  css-color-keywords@1.0.0:
-    optional: true
-
   css-declaration-sorter@7.4.0(postcss@8.5.9):
     dependencies:
       postcss: 8.5.9
-
-  css-gradient-parser@0.0.17:
-    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -14674,13 +14466,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
-
-  css-to-react-native@3.2.0:
-    dependencies:
-      camelize: 1.0.1
-      css-color-keywords: 1.0.0
-      postcss-value-parser: 4.2.0
-    optional: true
 
   css-tree@2.2.1:
     dependencies:
@@ -14838,7 +14623,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  docus@5.10.0(ee44486cc9cce13b53ac37d05ffe55cc):
+  docus@5.10.0(b0c20b4919a47b742c5cfd85214d64fb):
     dependencies:
       '@ai-sdk/gateway': 3.0.96(zod@4.3.6)
       '@ai-sdk/mcp': 1.0.36(zod@4.3.6)
@@ -14868,7 +14653,7 @@ snapshots:
       motion-v: 2.2.1(@vueuse/core@14.2.1(vue@3.5.33(typescript@5.9.3)))(vue@3.5.33(typescript@5.9.3))
       nuxt: 4.4.2(817853b61f98a69df6ddde0c23e29360)
       nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 6.4.8(cba6cfc151a7d083c92ea9c04b33f740)
+      nuxt-og-image: 6.4.8(d9231ed88b8bf12d212bd575343ab704)
       pkg-types: 2.3.0
       scule: 1.3.0
       shiki-stream: 0.1.4(vue@3.5.33(typescript@5.9.3))
@@ -15069,9 +14854,6 @@ snapshots:
   embla-carousel@8.6.0: {}
 
   emoji-regex-xs@1.0.0: {}
-
-  emoji-regex-xs@2.0.1:
-    optional: true
 
   emoji-regex@10.6.0: {}
 
@@ -15593,9 +15375,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fflate@0.7.4:
-    optional: true
-
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -16056,9 +15835,6 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
-
-  hex-rgb@4.3.0:
-    optional: true
 
   hey-listen@1.0.8: {}
 
@@ -16529,12 +16305,6 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
-
-  linebreak@1.1.0:
-    dependencies:
-      base64-js: 0.0.8
-      unicode-trie: 2.0.0
-    optional: true
 
   linkifyjs@4.3.2: {}
 
@@ -17544,7 +17314,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.4.8(cba6cfc151a7d083c92ea9c04b33f740):
+  nuxt-og-image@6.4.8(d9231ed88b8bf12d212bd575343ab704):
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
@@ -17579,12 +17349,8 @@ snapshots:
       unplugin: 3.0.0
       unstorage: 1.17.5(@upstash/redis@1.37.0)(db0@0.3.4(@electric-sql/pglite@0.4.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260413.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)))(ioredis@5.10.1)
     optionalDependencies:
-      '@resvg/resvg-js': 2.6.2
-      '@resvg/resvg-wasm': 2.6.2
       '@takumi-rs/core': 0.73.1
       fontless: 0.2.1(@upstash/redis@1.37.0)(db0@0.3.4(@electric-sql/pglite@0.4.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260413.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)))(ioredis@5.10.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      playwright-core: 1.59.1
-      satori: 0.19.3
       sharp: 0.34.5
       tailwindcss: 4.2.4
       unifont: 0.7.4
@@ -18425,20 +18191,11 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  pako@0.2.9:
-    optional: true
-
   pako@1.0.11: {}
 
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parse-css-color@0.2.1:
-    dependencies:
-      color-name: 1.1.4
-      hex-rgb: 4.3.0
-    optional: true
 
   parse-entities@4.0.2:
     dependencies:
@@ -18539,9 +18296,6 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
-
-  playwright-core@1.59.1:
-    optional: true
 
   pluralize@8.0.0: {}
 
@@ -19253,21 +19007,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  satori@0.19.3:
-    dependencies:
-      '@shuding/opentype.js': 1.4.0-beta.0
-      css-background-parser: 0.1.0
-      css-box-shadow: 1.0.0-3
-      css-gradient-parser: 0.0.17
-      css-to-react-native: 3.2.0
-      emoji-regex-xs: 2.0.1
-      escape-html: 1.0.3
-      linebreak: 1.1.0
-      parse-css-color: 0.2.1
-      postcss-value-parser: 4.2.0
-      yoga-layout: 3.2.1
-    optional: true
-
   sax@1.6.0: {}
 
   scule@1.3.0: {}
@@ -19609,9 +19348,6 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
-  string.prototype.codepointat@0.2.1:
-    optional: true
-
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -19936,6 +19672,8 @@ snapshots:
       magic-string: 0.30.21
       unplugin: 2.3.11
 
+  undici-types@6.21.0: {}
+
   undici-types@7.19.2: {}
 
   unenv@2.0.0-rc.24:
@@ -19947,12 +19685,6 @@ snapshots:
       hookable: 6.1.1
 
   unicode-emoji-modifier-base@1.0.0: {}
-
-  unicode-trie@2.0.0:
-    dependencies:
-      pako: 0.2.9
-      tiny-inflate: 1.0.3
-    optional: true
 
   unicorn-magic@0.3.0: {}
 
@@ -20291,6 +20023,23 @@ snapshots:
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
 
+  vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
@@ -20308,9 +20057,9 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest-environment-nuxt@2.0.0(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(playwright-core@1.59.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
+  vitest-environment-nuxt@2.0.0(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
-      '@nuxt/test-utils': 4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(playwright-core@1.59.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+      '@nuxt/test-utils': 4.0.2(crossws@0.4.5(srvx@0.11.15))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -20326,6 +20075,34 @@ snapshots:
       - typescript
       - vite
       - vitest
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -20639,9 +20416,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
-
-  yoga-layout@3.2.1:
-    optional: true
 
   youch-core@0.3.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Resolve `shelve run dev` (and other `package.json` scripts) via the detected package manager instead of treating the script name as a binary
- Add global `--debug` flag and `SHELVE_DEBUG=1` for verbose CLI logging
- Fix overlapping spinner/error output on API failures (single clean `spinner.cancel()` line)
- Add `@types/node` to fix `NodeJS` namespace errors in the CLI package

## Test plan

- [ ] `pnpm add -g @shelve/cli@latest` after release (or link locally from this branch)
- [ ] `shelve -v` shows the CLI version (not the cwd project version)
- [ ] `shelve --debug run dev` logs resolved command + spawn details
- [ ] `shelve run dev` starts the app when secrets load successfully
- [ ] Invalid/missing token shows one clean error line (no overlapping spinner text)
- [ ] `shelve logout && shelve login` then `shelve run dev` works without `SHELVE_TOKEN` in `.env`
- [ ] Merge Version packages PR and publish `@shelve/cli` patch release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--debug` flag and `SHELVE_DEBUG` environment variable support for verbose logging

* **Bug Fixes**
  * Fixed script resolution for `shelve run` commands
  * Fixed spinner failure messages overlapping with error output
  * Improved API error messages and handling with cache fallback support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/shelve/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->