### PR TITLE
feat(cli): agent-friendly CLI, docs, and Docus skill

### DIFF
--- a/.changeset/cli-agent-friendly.md
+++ b/.changeset/cli-agent-friendly.md
@@ -1,0 +1,5 @@
+---
+"@shelve/cli": minor
+---
+
+Add agent-friendly global flags (`--json`, `--quiet`, `--yes`, `--non-interactive`), structured JSON errors on stderr, non-interactive guards across all commands, and machine-readable output for query commands. Includes `login --token`, `generate --type`, HTTP debug logging, fixes silent fetch failures in `shelve run`, full CLI documentation on shelve.cloud, and a Docus-published agent skill at `/.well-known/skills/`.

--- a/.changeset/cli-agent-friendly.md
+++ b/.changeset/cli-agent-friendly.md
@@ -2,4 +2,4 @@
 "@shelve/cli": minor
 ---
 
-Add agent-friendly global flags (`--json`, `--quiet`, `--yes`, `--non-interactive`), structured JSON errors on stderr, non-interactive guards across all commands, and machine-readable output for query commands. Includes `login --token`, `generate --type`, HTTP debug logging, fixes silent fetch failures in `shelve run`, full CLI documentation on shelve.cloud, and a Docus-published agent skill at `/.well-known/skills/`.
+Add agent-friendly global flags (`--json`, `--quiet`, `--yes`, `--non-interactive`), structured JSON errors on stderr, non-interactive guards across all commands, and machine-readable output for query commands. Adds `shelve doctor`, `run` spawn JSON events, GitHub Action, CI playground smoke tests, LP skills manifest check, troubleshooting docs, `shelve-app` agent skill, and llms.txt skill links. Includes `login --token`, `generate --type`, HTTP debug logging, fixes silent fetch failures in `shelve run`, full CLI documentation on shelve.cloud, and a Docus-published agent skill at `/.well-known/skills/`.

--- a/.github/actions/shelve-run/README.md
+++ b/.github/actions/shelve-run/README.md
@@ -1,0 +1,49 @@
+# Shelve Run GitHub Action
+
+Composite action that runs a command with secrets injected from [Shelve](https://shelve.cloud) via `@shelve/cli run`.
+
+## Usage
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/shelve-run
+        with:
+          token: ${{ secrets.SHELVE_TOKEN }}
+          team-slug: my-team
+          project: my-app
+          env: ci
+          command: pnpm test
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `command` | yes | — | Command after `--` |
+| `token` | yes | — | API token |
+| `team-slug` | yes | — | Team slug |
+| `project` | yes | — | Project name |
+| `env` | no | `''` | Environment (or set repo variable `SHELVE_DEFAULT_ENV`) |
+| `url` | no | `https://app.shelve.cloud` | Shelve instance URL |
+| `cli-version` | no | `latest` | `@shelve/cli` npm version |
+
+## Notes
+
+- Uses `SHELVE_*` environment variables internally — no token on the command line.
+- Passes `--non-interactive` so CI never hangs on prompts.
+- Prefer scoped, expiring tokens from [app.shelve.cloud/user/tokens](https://app.shelve.cloud/user/tokens).
+
+## Validate setup first
+
+```yaml
+- run: npx @shelve/cli doctor --json
+  env:
+    SHELVE_TOKEN: ${{ secrets.SHELVE_TOKEN }}
+    SHELVE_TEAM_SLUG: my-team
+    SHELVE_PROJECT: my-app
+```

--- a/.github/actions/shelve-run/README.md
+++ b/.github/actions/shelve-run/README.md
@@ -30,7 +30,7 @@ jobs:
 | `project` | yes | — | Project name |
 | `env` | no | `''` | Environment (or set repo variable `SHELVE_DEFAULT_ENV`) |
 | `url` | no | `https://app.shelve.cloud` | Shelve instance URL |
-| `cli-version` | no | `latest` | `@shelve/cli` npm version |
+| `cli-version` | no | `5` | `@shelve/cli` npm version (major pin) |
 
 ## Notes
 

--- a/.github/actions/shelve-run/action.yml
+++ b/.github/actions/shelve-run/action.yml
@@ -1,0 +1,45 @@
+name: Shelve Run
+description: Inject secrets from Shelve and run a command (wraps `shelve run -- …`)
+inputs:
+  command:
+    description: Command to run after `--` (e.g. `pnpm test` or `npm run build`)
+    required: true
+  token:
+    description: Shelve API token (use `${{ secrets.SHELVE_TOKEN }}`)
+    required: true
+  team-slug:
+    description: Shelve team slug
+    required: true
+  project:
+    description: Shelve project name
+    required: true
+  env:
+    description: Shelve environment name (optional; uses SHELVE_DEFAULT_ENV if omitted)
+    required: false
+    default: ''
+  url:
+    description: Shelve instance URL
+    required: false
+    default: 'https://app.shelve.cloud'
+  cli-version:
+    description: npm version of @shelve/cli to run (default latest)
+    required: false
+    default: 'latest'
+runs:
+  using: composite
+  steps:
+    - name: Run with Shelve
+      shell: bash
+      env:
+        SHELVE_TOKEN: ${{ inputs.token }}
+        SHELVE_TEAM_SLUG: ${{ inputs.team-slug }}
+        SHELVE_PROJECT: ${{ inputs.project }}
+        SHELVE_URL: ${{ inputs.url }}
+        SHELVE_DEFAULT_ENV: ${{ inputs.env }}
+      run: |
+        set -euo pipefail
+        ENV_FLAG=""
+        if [ -n "${{ inputs.env }}" ]; then
+          ENV_FLAG="--env ${{ inputs.env }}"
+        fi
+        npx --yes "@shelve/cli@${{ inputs.cli-version }}" run ${ENV_FLAG} --non-interactive -- ${{ inputs.command }}

--- a/.github/actions/shelve-run/action.yml
+++ b/.github/actions/shelve-run/action.yml
@@ -22,9 +22,9 @@ inputs:
     required: false
     default: 'https://app.shelve.cloud'
   cli-version:
-    description: npm version of @shelve/cli to run (default latest)
+    description: npm version of @shelve/cli to run (default major 5)
     required: false
-    default: 'latest'
+    default: '5'
 runs:
   using: composite
   steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           pnpm play:fail
           code=$?
           set -e
-          test "$code" -eq 1
+          test "$code" -eq 7
 
   lp-agent-skills:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,17 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.15.0
           cache: pnpm
@@ -38,15 +40,17 @@ jobs:
   cli-playground:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.15.0
           cache: pnpm
@@ -71,15 +75,17 @@ jobs:
   lp-agent-skills:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.15.0
           cache: pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,61 @@ jobs:
 
       - name: Run tests
         run: pnpm run test
+
+  cli-playground:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Playground — JSON config
+        run: pnpm play:json
+
+      - name: Playground — run start
+        run: pnpm play:start
+
+      - name: Playground — failing exit code
+        run: |
+          set +e
+          pnpm play:fail
+          code=$?
+          set -e
+          test "$code" -eq 1
+
+  lp-agent-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build landing (prerender skills)
+        run: pnpm build:lp
+
+      - name: Verify /.well-known/skills manifest
+        run: test -f apps/lp/.output/public/.well-known/skills/index.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,4 @@ More details (progressive disclosure):
 - [Build env and outputs](docs/agents/build-env.md)
 - [Reference docs](docs/agents/docs-links.md)
 - [AI collaboration rules](docs/agents/ai-workflow.md)
+- [Shelve CLI for agents & automation](docs/agents/cli.md) — install skill: `npx skills add https://shelve.cloud`

--- a/apps/lp/content/docs/3.cli/1.init.md
+++ b/apps/lp/content/docs/3.cli/1.init.md
@@ -7,6 +7,8 @@ The `init` command prepares a repository for use with Shelve and, crucially, kee
 
 ```bash [terminal]
 shelve init
+shelve init --cwd ./packages/my-app
+shelve --json init
 ```
 
 ## What it does
@@ -28,6 +30,8 @@ Each ignore file is framed with `# shelve-managed-block` / `# end shelve-managed
   Directory to initialize. Defaults to the current working directory.
   ::
 ::
+
+With global `--json`, stdout returns `{ writtenFiles, skippedFiles, gitignoreUpdated }`.
 
 ## Why this matters
 

--- a/apps/lp/content/docs/3.cli/10.agents-automation.md
+++ b/apps/lp/content/docs/3.cli/10.agents-automation.md
@@ -11,7 +11,8 @@ Prefer **`shelve run -- <cmd>`** over **`shelve pull`**. `run` keeps secrets in 
 
 ## Recommended workflow
 
-1. Set context once with environment variables (no `shelve login` prompt required):
+1. Run **`shelve doctor --json`** (or `shelve doctor`) to validate setup.
+2. Set context once with environment variables (no `shelve login` prompt required):
 
 ```bash [terminal]
 export SHELVE_TOKEN="shlv_…"
@@ -69,6 +70,7 @@ In agent shells, **`shelve pull` without `--yes` fails immediately** with code `
 
 | Command | `data` shape |
 |---------|----------------|
+| `doctor` | `{ healthy, checks[], exitCodes, errorCodes }` |
 | `config` | Merged config; `token` redacted as `"***"` |
 | `me` | `{ loggedIn, username?, email? }` |
 | `push` | `{ env, variableCount, pushed }` |
@@ -80,7 +82,7 @@ In agent shells, **`shelve pull` without `--yes` fails immediately** with code `
 | `generate` | `{ type, path }` |
 | `upgrade` | `{ previous, current, updated }` |
 
-`shelve run` inherits the child stdio; only **startup errors** are structured on stderr.
+`shelve run` inherits the child stdio. Startup errors are structured on stderr; with `--json`, a spawn event is also emitted on stderr: `{ "ok": true, "event": "child_spawned", "env", "variableCount", "keys", "command", "pid" }`.
 
 ## Exit codes
 
@@ -110,7 +112,7 @@ shelve --debug run --env preview -- pnpm build
 
 ## Install the agent skill
 
-Shelve publishes an [Agent Skill](https://docus.dev/en/ai/skills) at `/.well-known/skills/` on [shelve.cloud](https://shelve.cloud). Install it into Cursor, Claude Code, or other supported agents:
+Shelve publishes [Agent Skills](https://docus.dev/en/ai/skills) at `/.well-known/skills/` on [shelve.cloud](https://shelve.cloud) (`shelve` + `shelve-app`):
 
 ```bash [terminal]
 npx skills add https://shelve.cloud

--- a/apps/lp/content/docs/3.cli/10.agents-automation.md
+++ b/apps/lp/content/docs/3.cli/10.agents-automation.md
@@ -1,0 +1,130 @@
+---
+title: Agents & automation
+description: Run the Shelve CLI from CI, scripts, and AI coding agents with global flags, JSON output, and non-interactive guards.
+---
+
+The Shelve CLI is designed to work in **CI**, **shell scripts**, and **AI agent shells** (Cursor, Claude Code, Codex, …) without hanging on prompts or polluting logs with spinners.
+
+::callout{type="warning"}
+Prefer **`shelve run -- <cmd>`** over **`shelve pull`**. `run` keeps secrets in the child process memory only. `pull` writes plaintext to disk where agents can read them.
+::
+
+## Recommended workflow
+
+1. Set context once with environment variables (no `shelve login` prompt required):
+
+```bash [terminal]
+export SHELVE_TOKEN="shlv_…"
+export SHELVE_TEAM_SLUG="my-team"
+export SHELVE_PROJECT="my-app"
+export SHELVE_DEFAULT_ENV="development"   # optional
+export SHELVE_URL="https://app.shelve.cloud" # optional
+```
+
+2. Run **`shelve init`** once per repo (agent ignore files + `.gitignore` block).
+3. Inject secrets with **`shelve run -- pnpm dev`** (or your command).
+4. Use **`--json`** when a script needs to parse output.
+5. Use **`--non-interactive`** (or rely on agent/CI auto-detection) so missing flags fail fast.
+
+## Global flags
+
+These flags can appear **before or after** the subcommand (for example `shelve run --json -- pnpm dev` or `shelve --json config`):
+
+::field-group
+  ::field{name="--json" type="boolean"}
+  Success → JSON on **stdout**: `{ "ok": true, "command"?: string, "data"?: object }`.  
+  Errors → JSON on **stderr**: `{ "ok": false, "error": { "code", "message", "status"?, "hint"? } }`.  
+  Secret **values are never** included in JSON output.
+  ::
+
+  ::field{name="--quiet" alias="-q" type="boolean"}
+  Suppress clack intro/outro/spinners. Minimal text output only.
+  ::
+
+  ::field{name="--yes" alias="-y" type="boolean"}
+  Skip confirmation prompts (`pull`, `push` when `confirmChanges` is enabled, etc.).
+  ::
+
+  ::field{name="--non-interactive" type="boolean"}
+  Fail with a structured error instead of prompting when required input is missing (`MISSING_*`, `AUTH_REQUIRED`, …).
+  ::
+
+  ::field{name="--debug" type="boolean"}
+  Verbose debug logs. Also enabled by `SHELVE_DEBUG=1` or `DEBUG=true`. HTTP requests are logged without Authorization headers or secret values.
+  ::
+::
+
+### Auto non-interactive mode
+
+The CLI enters non-interactive mode when any of these is true:
+
+- `--non-interactive` is passed
+- `CI=true` or `CI=1`
+- The shell is detected as an AI agent via [`std-env`](https://github.com/unjs/std-env) (`cursor`, `claude`, `codex`, …)
+- `AI_AGENT` is set (force-detect)
+
+In agent shells, **`shelve pull` without `--yes` fails immediately** with code `AGENT_BLOCKED` instead of prompting.
+
+## JSON output by command
+
+| Command | `data` shape |
+|---------|----------------|
+| `config` | Merged config; `token` redacted as `"***"` |
+| `me` | `{ loggedIn, username?, email? }` |
+| `push` | `{ env, variableCount, pushed }` |
+| `pull` | `{ env, variableCount, file, keys[] }` — no values |
+| `init` | `{ writtenFiles, skippedFiles, gitignoreUpdated }` |
+| `login` | `{ username, email }` |
+| `create` | `{ name, slug, configPath }` |
+| `logout` | `{ loggedOut: true }` |
+| `generate` | `{ type, path }` |
+| `upgrade` | `{ previous, current, updated }` |
+
+`shelve run` inherits the child stdio; only **startup errors** are structured on stderr.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | CLI, API, or validation error |
+| `128 + n` | Child killed by signal (`run`) |
+| `129` | Parent process gone / stdin EIO |
+| `130` / `143` | SIGINT / SIGTERM (forwarded from `run`) |
+
+## Examples
+
+```bash [terminal]
+# Machine-readable config (token redacted)
+shelve --json config
+
+# CI push without prompts
+shelve --non-interactive --yes push --env staging
+
+# Agent-safe dev server
+shelve run -- pnpm dev
+
+# Debug API round-trip
+shelve --debug run --env preview -- pnpm build
+```
+
+## Install the agent skill
+
+Shelve publishes an [Agent Skill](https://docus.dev/en/ai/skills) at `/.well-known/skills/` on [shelve.cloud](https://shelve.cloud). Install it into Cursor, Claude Code, or other supported agents:
+
+```bash [terminal]
+npx skills add https://shelve.cloud
+```
+
+The skill teaches agents the correct Shelve workflows, flags, and security rules (prefer `run`, avoid disk writes, use `SHELVE_*` env vars).
+
+## Local testing (contributors)
+
+From the Shelve monorepo, use the zero-network playground:
+
+```bash [terminal]
+pnpm play
+pnpm play -- --json config
+```
+
+See the [playground README](https://github.com/HugoRCD/shelve/tree/main/playground/run) on GitHub.

--- a/apps/lp/content/docs/3.cli/10.agents-automation.md
+++ b/apps/lp/content/docs/3.cli/10.agents-automation.md
@@ -22,10 +22,10 @@ export SHELVE_DEFAULT_ENV="development"   # optional
 export SHELVE_URL="https://app.shelve.cloud" # optional
 ```
 
-2. Run **`shelve init`** once per repo (agent ignore files + `.gitignore` block).
-3. Inject secrets with **`shelve run -- pnpm dev`** (or your command).
-4. Use **`--json`** when a script needs to parse output.
-5. Use **`--non-interactive`** (or rely on agent/CI auto-detection) so missing flags fail fast.
+3. Run **`shelve init`** once per repo (agent ignore files + `.gitignore` block).
+4. Inject secrets with **`shelve run -- pnpm dev`** (or your command).
+5. Use **`--json`** when a script needs to parse output.
+6. Use **`--non-interactive`** (or rely on agent/CI auto-detection) so missing flags fail fast.
 
 ## Global flags
 

--- a/apps/lp/content/docs/3.cli/10.agents-automation.md
+++ b/apps/lp/content/docs/3.cli/10.agents-automation.md
@@ -14,13 +14,13 @@ Prefer **`shelve run -- <cmd>`** over **`shelve pull`**. `run` keeps secrets in 
 1. Run **`shelve doctor --json`** (or `shelve doctor`) to validate setup.
 2. Set context once with environment variables (no `shelve login` prompt required):
 
-```bash [terminal]
-export SHELVE_TOKEN="shlv_…"
-export SHELVE_TEAM_SLUG="my-team"
-export SHELVE_PROJECT="my-app"
-export SHELVE_DEFAULT_ENV="development"   # optional
-export SHELVE_URL="https://app.shelve.cloud" # optional
-```
+   ```bash [terminal]
+   export SHELVE_TOKEN="shlv_…"
+   export SHELVE_TEAM_SLUG="my-team"
+   export SHELVE_PROJECT="my-app"
+   export SHELVE_DEFAULT_ENV="development"   # optional
+   export SHELVE_URL="https://app.shelve.cloud" # optional
+   ```
 
 3. Run **`shelve init`** once per repo (agent ignore files + `.gitignore` block).
 4. Inject secrets with **`shelve run -- pnpm dev`** (or your command).

--- a/apps/lp/content/docs/3.cli/11.troubleshooting.md
+++ b/apps/lp/content/docs/3.cli/11.troubleshooting.md
@@ -1,0 +1,125 @@
+---
+title: Troubleshooting
+description: Symptom → cause → fix for the Shelve CLI and agent automation.
+---
+
+Quick fixes for the most common CLI issues. Run **`shelve doctor`** (or **`shelve --json doctor`**) first — it checks config, auth, API, cache, and agent context in one shot.
+
+```bash [terminal]
+shelve doctor
+shelve --json doctor
+```
+
+## Error codes
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `AGENT_BLOCKED` | `pull` in an AI agent shell without `--yes` | Use `shelve run -- <cmd>` or pass `--yes` if disk `.env` is required |
+| `AUTH_REQUIRED` | No token | `export SHELVE_TOKEN=…` or `shelve login` |
+| `CONFIG_MISSING` | No `shelve.json` and missing env | Create config or set `SHELVE_TEAM_SLUG` + `SHELVE_PROJECT` |
+| `MISSING_ENV` | No environment selected | `--env staging` or `defaultEnv` in config |
+| `MISSING_INPUT` | Non-interactive mode missing a flag | Pass the flag shown in the error hint |
+| `FETCH_FAILED` | Network/API failure, no cache | Go online once, or use `--offline` if cache exists |
+| `FORBIDDEN` | Token lacks scope | Create a token with read/write for the team/project |
+| `PROJECT_NOT_FOUND` | Project missing | Enable `autoCreateProject` or `shelve create` |
+
+See also `shelve --help` for the full list of structured error codes.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | CLI or API error |
+| `128 + n` | Child killed by signal (`run`) |
+| `129` | Parent process gone / stdin EIO |
+| `130` / `143` | SIGINT / SIGTERM (often treated as clean shutdown in `run`) |
+
+## Common symptoms
+
+### CLI hangs waiting for input
+
+**Cause:** Interactive prompt (login, missing `--env`, confirmation).
+
+**Fix:**
+
+```bash [terminal]
+export SHELVE_TOKEN=…
+export SHELVE_TEAM_SLUG=…
+export SHELVE_PROJECT=…
+shelve --non-interactive doctor
+```
+
+### `shelve run dev` exits instantly
+
+**Cause:** Script resolution failed or script exits immediately.
+
+**Fix:**
+
+```bash [terminal]
+shelve run --debug dev
+shelve run -- pnpm dev
+```
+
+### Secrets not updated after Shelve UI change
+
+**Cause:** Old process env or stale cache.
+
+**Fix:** Restart with `shelve run`, or use `--watch --restart-on-change`.
+
+### `pull` fails in Cursor / Claude Code
+
+**Cause:** Agent guard (`AGENT_BLOCKED`).
+
+**Fix:** Prefer `shelve run -- <cmd>`. Only `shelve pull --yes` if you explicitly need a `.env` file.
+
+### Offline / plane mode
+
+**Fix:**
+
+```bash [terminal]
+# After one successful online run:
+shelve run --offline -- pnpm build
+```
+
+### JSON automation parse errors
+
+- Success → **stdout**: `{ "ok": true, "data": … }`
+- Errors → **stderr**: `{ "ok": false, "error": { "code", "message" } }`
+- `run` spawn metadata → **stderr** event: `{ "ok": true, "event": "child_spawned", … }`
+
+Secret **values** are never included in JSON output.
+
+## CI / GitHub Actions
+
+Use the composite action:
+
+```yaml
+- uses: ./.github/actions/shelve-run
+  with:
+    token: ${{ secrets.SHELVE_TOKEN }}
+    team-slug: my-team
+    project: my-app
+    env: ci
+    command: pnpm test
+```
+
+Validate secrets before the main job:
+
+```yaml
+- run: npx @shelve/cli --json doctor
+  env:
+    SHELVE_TOKEN: ${{ secrets.SHELVE_TOKEN }}
+    SHELVE_TEAM_SLUG: my-team
+    SHELVE_PROJECT: my-app
+```
+
+## Agent skill
+
+Install the published skills:
+
+```bash [terminal]
+npx skills add https://shelve.cloud
+```
+
+Catalog: `https://shelve.cloud/.well-known/skills/index.json` (skills: `shelve`, `shelve-app`).

--- a/apps/lp/content/docs/3.cli/2.index.md
+++ b/apps/lp/content/docs/3.cli/2.index.md
@@ -32,7 +32,9 @@ pnpm add -D @shelve/cli
 | [`config`](/docs/cli/config) | Show merged configuration |
 | [`generate`](/docs/cli/generate) | Generate `.env.example` or ESLint config |
 | [`upgrade`](/docs/cli/upgrade) | Update the CLI package |
+| [`doctor`](/docs/cli/troubleshooting) | Validate config, auth, API, and cache |
 | [`agents-automation`](/docs/cli/agents-automation) | Global flags, JSON output, CI & agents |
+| [`troubleshooting`](/docs/cli/troubleshooting) | Error codes and common fixes |
 
 ## Global flags
 

--- a/apps/lp/content/docs/3.cli/2.index.md
+++ b/apps/lp/content/docs/3.cli/2.index.md
@@ -5,67 +5,72 @@ title: CLI
 description: Shelve CLI is a command-line interface designed for the Shelve app.
 ---
 
-The CLI serves as a command-line interface designed for the [Shelve app](https://dub.sh/shelve). Facilitating the seamless transfer of environment variables for project collaboration within a team directly through the terminal interface, but way more other features are and will be available !
+The CLI is the primary way to sync secrets between your terminal and [Shelve](https://shelve.cloud). Use it to **inject** variables at runtime (`shelve run`), **push** local changes upstream, or **pull** secrets to disk when you really need a `.env` file.
+
+::callout{type="tip"}
+New to AI agents or CI? Start with [Agents & automation](/docs/cli/agents-automation) and install the published skill: `npx skills add https://shelve.cloud`
+::
 
 ## Installation
 
-To install the CLI, please refer to the [Quickstart](/docs/getting-started/quickstart) guide.
+Install `@shelve/cli` in your project or globally. See the [Quickstart](/docs/getting-started/quickstart) guide.
+
+```bash [terminal]
+pnpm add -D @shelve/cli
+```
+
+## Command overview
+
+| Command | Description |
+|---------|-------------|
+| [`run`](/docs/cli/run) | Inject secrets into a child process (preferred) |
+| [`init`](/docs/cli/init) | Agent-safe ignore files + `.gitignore` block |
+| [`login`](/docs/cli/login-logout) / [`logout`](/docs/cli/login-logout) | Manage stored credentials |
+| [`me`](/docs/cli/login-logout) | Show the logged-in user |
+| [`push`](/docs/cli/push-pull) / [`pull`](/docs/cli/push-pull) | Sync secrets with Shelve |
+| [`create`](/docs/cli/create) | Create a project + `shelve.json` |
+| [`config`](/docs/cli/config) | Show merged configuration |
+| [`generate`](/docs/cli/generate) | Generate `.env.example` or ESLint config |
+| [`upgrade`](/docs/cli/upgrade) | Update the CLI package |
+| [`agents-automation`](/docs/cli/agents-automation) | Global flags, JSON output, CI & agents |
+
+## Global flags
+
+Available on **every** command (before or after the subcommand):
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--json` | | Machine-readable stdout; structured errors on stderr |
+| `--quiet` | `-q` | No spinners or clack UI |
+| `--yes` | `-y` | Skip confirmation prompts |
+| `--non-interactive` | | Fail instead of prompting |
+| `--debug` | | Verbose logs (`SHELVE_DEBUG=1`) |
 
 ## Configuration
 
-Configuration is loaded from cwd. You can use either shelve.json, shelve.config.json or .shelverc.json, but running the CLI without any configuration will create a shelve.json file.
+Configuration is loaded from the current working directory. Supported filenames: `shelve.json`, `shelve.config.json`, `.shelverc.json`. If none exists and a command requires config, the CLI can create `shelve.json` interactively (or fail in non-interactive mode).
 
-The CLI also has a json schema for the configuration file. that can be used to validate the configuration file [(see it here)](https://raw.githubusercontent.com/HugoRCD/shelve/main/packages/types/schema.json).
+JSON Schema: [shelve.cloud/schema.json](https://shelve.cloud/schema.json)
 
 ```json [shelve.json]
 {
+  "$schema": "https://shelve.cloud/schema.json",
   "slug": "nuxtlabs",
   "project": "@nuxt/ui",
-  "confirmChanges": true,
+  "defaultEnv": "development",
+  "confirmChanges": false,
   "autoCreateProject": true
 }
 ```
 
 ### Monorepo support
 
-Shelve natively supports monorepos, tf you are using a monorepo, Shelve will automatically detect the root of the monorepo and look for the global `shelve.json` file. You can define here common configurations for all the projects in the monorepo (the team `slug` for example):
+Shelve detects monorepo roots and **merges** the root `shelve.json` with the local one (shared team `slug`, per-package `project`, etc.):
 
 ::code-tree{default-value="shelve.json"}
 ```json [apps/app/shelve.json]
 {
-  "project": "@nuxt/app",
-  "confirmChanges": true
-}
-```
-
-```json [apps/app/package.json]
-{
-  "name": "@nuxt/app"
-}
-```
-
-```json [apps/api/shelve.json]
-{
-  "project": "@nuxt/api",
-  "envFileName": ".env.development"
-}
-```
-
-```json [apps/api/package.json]
-{
-  "name": "@nuxt/api"
-}
-```
-
-```json [packages/cli/shelve.json]
-{
-  "project": "@nuxt/cli"
-}
-```
-
-```json [packages/cli/package.json]
-{
-  "name": "@nuxt/cli"
+  "project": "@nuxt/app"
 }
 ```
 
@@ -74,56 +79,34 @@ Shelve natively supports monorepos, tf you are using a monorepo, Shelve will aut
   "slug": "nuxtlabs"
 }
 ```
-
-```json [package.json]
-{
-  "name": "nuxtlabs"
-}
-```
 ::
 
-### Monorepo usage
+Commands always run in the **current directory** — they do not automatically execute across every package in the monorepo.
 
-If you are using a monorepo, running a command at the root level will execute the command for all the projects in the monorepo that have a `shelve.json` file.
+## Configuration options
 
-Example:
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `project` | `string` | `SHELVE_PROJECT` or nearest `package.json` name | Project name |
+| `slug` | `string` | `SHELVE_TEAM_SLUG` | Team slug |
+| `token` | `string` | Keychain / `$XDG_CONFIG_HOME/.shelve` / `SHELVE_TOKEN` | API token |
+| `url` | `string` | `https://app.shelve.cloud` | Shelve instance URL |
+| `defaultEnv` | `string` | — | Default environment for `run`, `push`, `pull` |
+| `confirmChanges` | `boolean` | `false` | Confirm before push/pull writes |
+| `envFileName` | `string` | `.env` | Local env file name |
+| `autoUppercase` | `boolean` | `true` | Uppercase keys on push |
+| `autoCreateProject` | `boolean` | `true` | Create project if missing |
 
-```bash [terminal]
-shelve pull
-```
+## Environment variables
 
-This command will execute the `pull` command for all the projects in the monorepo that have a `shelve.json` file.
+| Variable | Description |
+|----------|-------------|
+| `SHELVE_PROJECT` | Project name |
+| `SHELVE_TEAM_SLUG` | Team slug |
+| `SHELVE_TOKEN` | Authentication token |
+| `SHELVE_URL` | Shelve instance URL |
+| `SHELVE_DEFAULT_ENV` | Default environment |
+| `SHELVE_DEBUG=1` | Enable debug logging |
+| `AI_AGENT` | Force AI-agent shell detection |
 
-```bash [apps/app/terminal]
-shelve pull
-```
-
-This command will execute the `pull` command for the `@nuxt/app` project.
-
-## Options
-
-Here are all the available options for the configuration file:
-
-| Option              | Type      | Default                                                                                | Description                                                             |
-|---------------------|-----------|----------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| `project`           | `string`  | `process.env.SHELVE_PROJECT` or nearest package.json name                              | The name of your project                                                |
-| `slug`              | `string`  | `process.env.SHELVE_TEAM_SLUG`                                                         | Your team slug (can be found in your team settings)                     |
-| `token`             | `string`  | OS keychain (preferred) or `$XDG_CONFIG_HOME/.shelve` after `shelve login`, or `process.env.SHELVE_TOKEN` | Authentication token created via app.shelve.cloud/user/tokens           |
-| `url`               | `string`  | `https://app.shelve.cloud`                                                             | URL of the Shelve instance                                              |
-| `defaultEnv`        | `string`  |                                                                                        | The default environment use by the command like `run`, `push` or `pull` |
-| `confirmChanges`    | `boolean` | `false`                                                                                | Whether to confirm changes before applying them                         |
-| `envFileName`       | `string`  | `.env`                                                                                 | Name of your environment file                                           |
-| `autoUppercase`     | `boolean` | `true`                                                                                 | Automatically uppercase environment variable keys                       |
-| `autoCreateProject` | `boolean` | `true`                                                                                 | Automatically create project if it doesn't exist                        |
-
-## Environment Variables
-
-The following environment variables can be used to override configuration options:
-
-| Variable             | Description                 |
-|----------------------|-----------------------------|
-| `SHELVE_PROJECT`     | Project name                |
-| `SHELVE_TEAM_SLUG`   | Team slug                   |
-| `SHELVE_TOKEN`       | Authentication token        |
-| `SHELVE_URL`         | Shelve instance URL         |
-| `SHELVE_DEFAULT_ENV` | Default env for CLI command |
+Credentials are stored in the **OS keychain** when available, with an XDG file fallback (`~/.config/.shelve`, mode `0600`).

--- a/apps/lp/content/docs/3.cli/3.run.md
+++ b/apps/lp/content/docs/3.cli/3.run.md
@@ -3,7 +3,7 @@ title: Run
 description: Inject secrets into your application at runtime without writing a .env file.
 ---
 
-`shelve run` spawns your command with every variable from your Shelve project already present in its environment. **No `.env` file is written** — secrets never touch disk.
+`shelve run` spawns your command with every variable from your Shelve project already present in its environment. **No plaintext `.env` file is written by `shelve run`** — encrypted cache files (for example under `~/.shelve/cache/`) may still be created for offline use.
 
 ```bash [terminal]
 shelve run -- <command> [args]

--- a/apps/lp/content/docs/3.cli/3.run.md
+++ b/apps/lp/content/docs/3.cli/3.run.md
@@ -3,57 +3,71 @@ title: Run
 description: Inject secrets into your application at runtime without writing a .env file.
 ---
 
-`shelve run` spawns your command with every variable from your Shelve project already present in its environment. No `.env` file is written, no secret ever touches disk.
+`shelve run` spawns your command with every variable from your Shelve project already present in its environment. **No `.env` file is written** — secrets never touch disk.
 
 ```bash [terminal]
 shelve run -- <command> [args]
 ```
 
-The double-dash is conventional — anything after `--` is passed verbatim to your command. For simple npm-style scripts, `shelve run dev` works too: it uses [`ni`](https://github.com/antfu-collective/ni) to detect your package manager and run the script.
+The double-dash is conventional — anything after `--` is passed verbatim to your command. For npm-style scripts, `shelve run dev` resolves the script from `package.json` and runs it directly (without a package-manager wrapper that prints `ELIFECYCLE` on Ctrl-C).
+
+::callout{type="tip"}
+If a script exits suspiciously fast, run `shelve run --debug -- pnpm dev` to see the resolved command, or use `shelve run -- pnpm dev` to bypass script resolution.
+::
 
 ## How it works
 
-1. Shelve reads your token (from the OS keychain or the XDG config file), resolves your team / project / environment, and fetches the variables for that env.
-2. The variables are spliced into a fresh environment map and merged onto your process's environment.
-3. Your command is spawned via `node:child_process.spawn`, in its own process group, so Shelve can forward `SIGINT` / `SIGTERM` cleanly.
-4. The exit code of your command becomes the exit code of `shelve run` — seamless in CI.
+1. The CLI reads your token (keychain, XDG file, or `SHELVE_TOKEN`), resolves team / project / environment, and fetches variables (or reads the encrypted cache).
+2. Variables are merged into a fresh environment map layered on `process.env`.
+3. Your command is spawned with `stdio: 'inherit'`.
+4. The child exit code is propagated to `shelve run`.
+
+On fetch failure, the CLI falls back to a fresh encrypted cache when available (unless `--no-cache` is set). Failures emit structured errors instead of silent exits.
 
 ## Examples
 
 ```bash [terminal]
-# Run your dev server with production-like secrets
-shelve run --env=preview -- pnpm dev
-
-# Short form when the command is a package.json script
-shelve run build
-
-# Explicit command + flags
+shelve run --env preview -- pnpm dev
+shelve run dev
 shelve run -- node scripts/migrate.ts --dry-run
+shelve --json run -- pnpm test   # JSON applies to CLI messages only; child keeps normal stdio
 ```
 
 ## Options
 
 ::field-group
   ::field{name="env" type="string"}
-  Environment to use (for example `development`, `preview`, `production`). Overrides `defaultEnv` from `shelve.json`.
+  Environment to use (`development`, `preview`, `production`, …). Falls back to `defaultEnv` in `shelve.json` or `SHELVE_DEFAULT_ENV`.
+  ::
+
+  ::field{name="template" type="string"}
+  Path to a `.env.template` file with `shelve://` references and literal values (see below).
+  ::
+
+  ::field{name="offline" type="boolean"}
+  Use **only** the encrypted offline cache. Fails if no cache exists for this project/environment.
+  ::
+
+  ::field{name="no-cache" type="boolean"}
+  Disable cache reads and writes entirely.
+  ::
+
+  ::field{name="cache-ttl" type="duration" default="24h"}
+  Cache freshness override. Accepts `500ms`, `30s`, `15m`, `2h`, `7d`, or milliseconds.
   ::
 
   ::field{name="watch" type="boolean"}
-  Restart the child process whenever variables change upstream. Combine with a dev server that already reloads on source edits.
+  Poll Shelve every ~5s for variable changes. Forwards `SIGHUP` to the child by default.
   ::
 
-  ::field{name="offline" type="'auto' | 'never' | 'only'" default="'auto'"}
-  How to use the encrypted offline cache. `auto` (default) refreshes variables from Shelve and falls back to the cache if the network is down. `never` disables the cache entirely. `only` refuses to make any network call.
-  ::
-
-  ::field{name="cache-ttl" type="duration" default="15m"}
-  How long a cached payload is considered fresh. Accepts `500ms`, `30s`, `15m`, `2h`, `7d`, or a raw number in milliseconds.
+  ::field{name="restart-on-change" type="boolean"}
+  With `--watch`, kill and respawn the child instead of sending `SIGHUP` (required when the child reads `process.env` only once).
   ::
 ::
 
 ## Secret references (`.env.template`)
 
-If a `.env.template` file is present in the current directory, Shelve uses it as a **layout** for the injected environment. Each line is either a literal value or a `shelve://` reference that resolves against the current environment:
+Commit a template and resolve secrets at runtime:
 
 ```bash [.env.template]
 NODE_ENV=production
@@ -62,39 +76,54 @@ PROD_DATABASE_URL=shelve://production/DATABASE_URL
 ```
 
 - Lines without `shelve://` pass through verbatim.
-- `shelve://KEY` pulls `KEY` from the current environment, optionally renaming it on the left-hand side.
-- `shelve://<env>/KEY` explicitly targets another environment — useful for mirroring production values into a preview command.
+- `shelve://KEY` pulls `KEY` from the current environment.
+- `shelve://<env>/KEY` targets another environment.
 
-References that cannot be resolved are reported in a grouped diagnostic and the command aborts before spawning the child, so you never run a process with partially-hydrated secrets.
+Run with:
+
+```bash [terminal]
+shelve run --template .env.template -- pnpm dev
+```
+
+Unresolved references are warned; the command still runs with literal placeholders.
 
 ## Encrypted offline cache
 
-After every successful fetch, Shelve writes the payload to `~/.shelve/cache/<hash>.cache`, sealed with a key derived from your current token via HKDF. The cache is scoped per team + project + environment; switching environments uses a different key.
+After every successful fetch, Shelve writes an AES-256-GCM payload to `~/.shelve/cache/`, keyed via HKDF from your API token.
 
-- Loss of the token invalidates the cache automatically (the derived key no longer matches).
-- Tampering with the cache file is detected via AES-GCM authentication tags — a modified file fails to decrypt.
-- Files are created with `0600` permissions; the directory with `0700`.
+- Token rotation or revocation invalidates the cache.
+- Tampering is detected (GCM auth tag).
+- Files are mode `0600`; directory `0700`.
 
-Use `--offline=only` on planes, in restricted CI environments, or anywhere outbound egress is blocked.
+```bash [terminal]
+shelve run --offline -- pnpm build
+```
 
 ## Watch mode
 
 ```bash [terminal]
+# Daemons that reload on SIGHUP
 shelve run --watch -- node server.js
-```
 
-With `--watch`, Shelve opens a server-sent events stream and listens for `variable.updated` / `variable.deleted` events on your project. When a change lands the child process is sent `SIGTERM`, waits for it to exit (or is killed after a grace period), and is respawned with the new environment. This is the closest thing to a managed "hot reload for secrets".
+# Node apps that need a full respawn for new env
+shelve run --watch --restart-on-change -- pnpm dev
+```
 
 ## AI-agent safety
 
-When `shelve run` is invoked from a shell whose environment looks like an AI coding agent (Cursor, Claude Code, Aider, Continue, Codex, …), it prints a reminder that secrets will only exist in the spawned process's memory and will never be visible to the agent itself. Unlike `shelve pull`, `run` never prompts — running with an agent attached is safe by design.
+Prefer `shelve run` in agent shells — secrets exist only in the child process memory.
+
+`shelve pull` is blocked in agent environments unless `--yes` is passed explicitly. See [Agents & automation](/docs/cli/agents-automation).
 
 ## Exit behaviour
 
 | Signal / event | Behaviour |
 |---|---|
-| Child exits normally | `shelve run` exits with the same code |
-| Child crashes | Shelve propagates the exit code |
-| `Ctrl-C` (`SIGINT`) | Forwarded to the entire process group; child terminates cleanly |
-| `SIGTERM` | Forwarded to the process group, grace period 5s, then `SIGKILL` |
-| Variable change (watch mode) | Child is respawned with the new env |
+| Child exits normally | Same exit code |
+| Child crashes | Exit code propagated |
+| Ctrl-C (`SIGINT`) | Forwarded to child tree; graceful shutdown |
+| `SIGTERM` / `SIGHUP` | Forwarded; 5s grace then `SIGKILL` |
+| Parent process gone | CLI tears down child tree (exit `129`) |
+| Watch reload | Child respawned or sent `SIGHUP` |
+
+Signal exits (`130`, `143`, `129`) are treated as normal shutdown in many paths.

--- a/apps/lp/content/docs/3.cli/4.login-logout.md
+++ b/apps/lp/content/docs/3.cli/4.login-logout.md
@@ -7,49 +7,60 @@ description: Authenticate the CLI against Shelve and manage stored credentials.
 
 ```bash [terminal]
 shelve login
+shelve login --token "$SHELVE_TOKEN"
 ```
 
-The CLI prompts for a token. Create one from the Shelve dashboard at [app.shelve.cloud/user/tokens](https://app.shelve.cloud/user/tokens), then paste it into the prompt. Tokens are [scopeable, expiring, and IP-bound](/docs/core-features/tokens) — prefer a narrowly-scoped token to your account-wide default.
+Create a token from the Shelve dashboard at [app.shelve.cloud/user/tokens](https://app.shelve.cloud/user/tokens). Tokens are [scopeable, expiring, and IP-bound](/docs/core-features/tokens).
+
+### Options
+
+::field-group
+  ::field{name="token" type="string"}
+  API token (alternative to the interactive prompt). `SHELVE_TOKEN` is also accepted without running `login`.
+  ::
+::
 
 ### Where the token is stored
 
-1. **OS keychain first** — Keychain on macOS, Credential Vault on Windows, Secret Service / GNOME Keyring / KWallet on Linux (via [`@napi-rs/keyring`](https://github.com/napi-rs/keyring)). The value is encrypted at rest and gated by the OS session.
-2. **XDG file fallback** — if the keychain is unavailable (headless CI containers, missing D-Bus on Linux, …) the CLI writes to `$XDG_CONFIG_HOME/.shelve` (typically `~/.config/.shelve`) with mode `0600`. A warning is printed so you know you are on the fallback path.
+1. **OS keychain** — Keychain (macOS), Credential Vault (Windows), Secret Service / GNOME Keyring (Linux) via [`@napi-rs/keyring`](https://github.com/napi-rs/keyring).
+2. **XDG file fallback** — `$XDG_CONFIG_HOME/.shelve` (typically `~/.config/.shelve`), mode `0600`, when the keychain is unavailable.
 
 ::callout{type="info"}
-Older CLI versions wrote credentials to `~/.shelve`. The first `login` / `logout` / `pull` you run with a v5 CLI will migrate the legacy file into the XDG location and delete the original.
+Legacy `~/.shelve` is migrated automatically on first read with v5+.
 ::
 
-### Me
+## Me
 
 ```bash [terminal]
 shelve me
+shelve --json me
 ```
 
-Prints the account the current token is attached to, the Shelve instance URL, and which storage backend holds the token.
+Human mode prints the logged-in username and email. JSON mode returns `{ "loggedIn": true, "username", "email" }` or `{ "loggedIn": false }`.
 
 ## Logout
 
 ```bash [terminal]
 shelve logout
+shelve --json logout
 ```
 
-Removes the token from the keychain (if present) and clears the XDG config. Subsequent CLI commands refuse to run until you log in again.
+Clears the keychain entry and XDG config. JSON returns `{ "loggedOut": true }`.
 
 ## Non-interactive environments
 
-In CI, a container, or any automation flow, skip `shelve login` entirely and pass the token via an environment variable:
+Skip `shelve login` in CI and agents — set `SHELVE_TOKEN` directly:
 
 ```bash [terminal]
-SHELVE_TOKEN="$SHELVE_TOKEN" shelve run -- pnpm test
+SHELVE_TOKEN="$SHELVE_TOKEN" shelve --non-interactive run -- pnpm test
 ```
 
-The CLI reads `SHELVE_TOKEN` before consulting the keychain or the XDG file. Pair it with a scoped, expiring token for least-privilege CI access.
+The CLI reads `SHELVE_TOKEN` before the keychain. Pair with scoped, expiring tokens for least privilege.
 
 ::callout{type="warning"}
-Never commit `SHELVE_TOKEN` to git. Use your CI provider's secrets UI or a runtime secret store (GitHub Actions secrets, Vercel project env vars, …).
+Never commit `SHELVE_TOKEN`. Use your CI provider's secrets store.
 ::
 
 ## Multiple accounts
 
-Only one account per machine is supported at a time. To switch accounts, `shelve logout` and `shelve login` again with the new token.
+One account per machine. To switch: `shelve logout`, then `shelve login` with the new token.

--- a/apps/lp/content/docs/3.cli/5.push-pull.md
+++ b/apps/lp/content/docs/3.cli/5.push-pull.md
@@ -3,37 +3,84 @@ title: Push and Pull
 description: Push and pull your secrets to and from Shelve.
 ---
 
-The `push` and `pull` commands enable you to send your secrets to Shelve and retrieve them back to your local machine. This is the essential feature of Shelve CLI, as it lets you securely store your secrets in Shelve and access them from your local machine, while also allowing you to share them with your team.
+`push` and `pull` sync secrets between your local `.env` file and Shelve. For day-to-day development — especially in **AI agent shells** — prefer [`shelve run`](/docs/cli/run) instead of `pull`.
 
 ## Push
 
-The `push` command allows you to send your secrets to Shelve. When you run the `push` command, you will be prompted to enter the environment name where you want to store your secrets.
+Upload variables from your local env file to Shelve:
 
 ```bash [terminal]
 shelve push
+shelve push --env staging
+shelve --non-interactive --yes push --env staging
+shelve --json push --env staging
 ```
 
-## Pull
-
-The `pull` command allows you to retrieve your secrets from Shelve. When you run the `pull` command, you will be prompted to enter the environment name from which you want to retrieve your secrets.
-
-```bash [terminal]
-shelve pull
-```
+Reads variables from `envFileName` in `shelve.json` (default `.env`).
 
 ### Options
 
 ::field-group
   ::field{name="env" type="string"}
-  Specify the environment to which you want to push or pull the variables
+  Target environment. Defaults to `defaultEnv` in `shelve.json` or `SHELVE_DEFAULT_ENV`.
+  ::
+
+  ::field{name="yes" type="boolean"}
+  Skip confirmation when `confirmChanges` is `true` in config. Also respects global `--yes`.
   ::
 ::
 
-You can configure a default environment in your `shelve.json` file to bypass the env prompt:
+JSON output: `{ "env", "variableCount", "pushed" }` (no secret values).
+
+## Pull
+
+Download variables from Shelve to your local env file:
+
+```bash [terminal]
+shelve pull
+shelve pull --env production
+shelve pull --env production --yes
+```
+
+### AI-agent guard
+
+When the CLI detects an AI agent shell (Cursor, Claude Code, Codex, …) or `AI_AGENT` is set, **`pull` fails with `AGENT_BLOCKED`** unless you pass `--yes`:
+
+```bash [terminal]
+# Explicit opt-in only — secrets will be written to disk
+shelve pull --yes --env development
+```
+
+::callout{type="warning"}
+Plaintext `.env` files can be read by AI agents. Run [`shelve init`](/docs/cli/init) and prefer [`shelve run`](/docs/cli/run).
+::
+
+### Options
+
+::field-group
+  ::field{name="env" type="string"}
+  Source environment.
+  ::
+
+  ::field{name="yes" type="boolean"}
+  Skip the agent disk-write confirmation and `confirmChanges` prompts.
+  ::
+::
+
+JSON output: `{ "env", "variableCount", "file", "keys[]" }` — values are never included.
+
+## Default environment
+
+Set `defaultEnv` to skip passing `--env` every time:
 
 ```json [shelve.json]
 {
   "defaultEnv": "development",
-  "slug": "shelve"
+  "slug": "my-team",
+  "project": "my-app"
 }
 ```
+
+## confirmChanges
+
+When `confirmChanges: true` in `shelve.json`, push and pull ask before writing. Skip with `--yes` or global `--yes` / `--non-interactive` automation flags.

--- a/apps/lp/content/docs/3.cli/6.create.md
+++ b/apps/lp/content/docs/3.cli/6.create.md
@@ -13,7 +13,11 @@ shelve create
 
 ```bash [terminal]
 shelve create --name my-project --slug my-team
+shelve --non-interactive create --name my-project --slug my-team
+shelve --json create --name my-project --slug my-team
 ```
+
+In non-interactive mode, both `--name` and `--slug` are required (or set `SHELVE_PROJECT` / `SHELVE_TEAM_SLUG`).
 
 ### Options
 

--- a/apps/lp/content/docs/3.cli/7.config.md
+++ b/apps/lp/content/docs/3.cli/7.config.md
@@ -3,40 +3,51 @@ title: Config
 description: Show the current configuration.
 ---
 
-The `config` command allows you to view the current configuration of Shelve CLI. When you run the `config` command, Shelve CLI will display the current configuration, including the token, the base URL, and everything else that will be used to interact with Shelve.
+The `config` command prints the **merged** configuration Shelve CLI will use in the current directory (local + monorepo root + environment variables).
 
 ```bash [terminal]
 shelve config
+shelve --json config
 ```
 
-Example output:
+## Human output
 
-```bash [terminal]
+Prints the config object to stdout (Node inspect style). The token is shown in full — avoid sharing this output.
+
+## JSON output
+
+With `--json`, stdout is:
+
+```json
 {
-  slug: 'hrcd',
-  project: 'shelve',
-  token: 'your-token',
-  url: 'https://app.shelve.cloud',
-  username: 'your-username',
-  email: 'your-email',
-  confirmChanges: false,
-  envFileName: '.env',
-  autoUppercase: true,
-  autoCreateProject: true,
-  monorepo: {
-    paths: [
-      '/Users/username/Dev/shelve',
-      '/Users/username/Dev/shelve/apps/base',
-      '/Users/username/Dev/shelve/apps/lp',
-      '/Users/username/Dev/shelve/apps/shelve',
-      '/Users/username/Dev/shelve/packages/cli',
-      '/Users/username/Dev/shelve/packages/utils',
-      '/Users/username/Dev/shelve/packages/types'
-    ]
-  },
-  workspaceDir: '/Users/username/Dev/shelve',
-  isMonoRepo: true,
-  isRoot: false,
-  '$schema': 'https://raw.githubusercontent.com/HugoRCD/shelve/main/packages/types/schema.json'
+  "ok": true,
+  "command": "config",
+  "data": {
+    "slug": "my-team",
+    "project": "my-app",
+    "token": "***",
+    "url": "https://app.shelve.cloud",
+    "defaultEnv": "development",
+    "confirmChanges": false,
+    "envFileName": ".env",
+    "autoUppercase": true,
+    "autoCreateProject": true,
+    "workspaceDir": "/path/to/project",
+    "isMonoRepo": false,
+    "isRoot": true
+  }
 }
 ```
+
+The token is always **redacted** as `"***"` in JSON mode.
+
+## What is included
+
+- Resolved `project`, `slug`, `url`, `defaultEnv`
+- Credential metadata (`username`, `email`) when logged in
+- Monorepo detection (`isMonoRepo`, `workspaceDir`, `monorepo.paths`)
+- Effective flags (`confirmChanges`, `envFileName`, …)
+
+If required fields are missing and you are in non-interactive mode, the command fails with `MISSING_SLUG`, `MISSING_PROJECT`, or `AUTH_REQUIRED` instead of prompting.
+
+See [Introduction](/docs/cli) for the full list of config keys and `SHELVE_*` environment variables.

--- a/apps/lp/content/docs/3.cli/8.generate.md
+++ b/apps/lp/content/docs/3.cli/8.generate.md
@@ -3,12 +3,45 @@ title: Generate
 description: Generate useful files for your project.
 ---
 
-The `generate` will prompt you to select the type of file you want to generate.
+Generate helper files from your current project context.
 
 ```bash [terminal]
 shelve generate
+shelve generate --type env-example
+shelve generate --type eslint
+shelve --json generate --type env-example
 ```
 
-## Env Example
+## Interactive mode
 
-The `.env.example` option allows you to generate an example `.env` file in your project. This file contains the environment variables required to run your project locally but does not contain any sensitive information. You can use this file as a template to create your own `.env` file.
+Without `--type`, the CLI prompts you to choose:
+
+- `.env.example` — keys from your local `.env` with placeholder values
+- ESLint config — fetches a starter `eslint.config.js`
+
+## Non-interactive mode
+
+Pass `--type` (required when `--non-interactive`, CI, or agent shell is active):
+
+| `--type` | Output |
+|----------|--------|
+| `env-example` | `{envFileName}.example` (default `.env.example`) |
+| `eslint` | `eslint.config.js` |
+
+JSON success: `{ "type", "path" }`.
+
+## Env example
+
+Generates an example file from your local env file keys — safe to commit, no real secret values:
+
+```bash [terminal]
+shelve generate --type env-example
+```
+
+## ESLint config
+
+Fetches a starter config from the Shelve templates repository. Optionally installs `eslint` and `@hrcd/eslint-config` when run interactively (skipped with `--yes` / non-interactive).
+
+```bash [terminal]
+shelve generate --type eslint
+```

--- a/apps/lp/content/docs/3.cli/8.generate.md
+++ b/apps/lp/content/docs/3.cli/8.generate.md
@@ -40,7 +40,7 @@ shelve generate --type env-example
 
 ## ESLint config
 
-Fetches a starter config from the Shelve templates repository. Optionally installs `eslint` and `@hrcd/eslint-config` when run interactively (skipped with `--yes` / non-interactive).
+Fetches a starter config from the Shelve templates repository. Optionally installs `eslint` and `@hrcd/eslint-config` when run interactively or when `--yes` auto-confirms; non-interactive runs skip the installs.
 
 ```bash [terminal]
 shelve generate --type eslint

--- a/apps/lp/content/docs/3.cli/9.upgrade.md
+++ b/apps/lp/content/docs/3.cli/9.upgrade.md
@@ -3,8 +3,33 @@ title: Upgrade
 description: Upgrade your Shelve CLI to the latest version.
 ---
 
-The `upgrade` command allows you to upgrade your Shelve CLI to the latest version. When you run the `upgrade` command, Shelve CLI will check for the latest version and upgrade your CLI if a newer version is available.
+Checks npm for a newer `@shelve/cli` version and updates the dependency in your project.
 
 ```bash [terminal]
 shelve upgrade
+shelve --json upgrade
 ```
+
+## Behaviour
+
+1. Compares the installed version with the npm `latest` tag.
+2. If already up to date, exits successfully.
+3. Otherwise runs `nypm addDependency('@shelve/cli@latest')`.
+
+Global `--yes` / non-interactive mode skips any interactive steps during the upgrade flow.
+
+## JSON output
+
+```json
+{
+  "ok": true,
+  "command": "upgrade",
+  "data": {
+    "previous": "5.0.3",
+    "current": "latest",
+    "updated": true
+  }
+}
+```
+
+When already current: `"updated": false` and `"current"` matches `"previous"`.

--- a/apps/lp/nuxt.config.ts
+++ b/apps/lp/nuxt.config.ts
@@ -43,6 +43,42 @@ export default defineNuxtConfig({
         contentFilters: [{ field: 'extension', operator: '=', value: 'md' }]
       },
       {
+        title: 'Agent Skills',
+        description: 'Installable AI agent skills (Agent Skills Discovery RFC)',
+        links: [
+          {
+            title: 'Skills catalog',
+            description: 'JSON index of all published skills',
+            href: '/.well-known/skills/index.json',
+          },
+          {
+            title: 'Install all skills',
+            description: 'Run: npx skills add https://shelve.cloud',
+            href: 'https://shelve.cloud/.well-known/skills/index.json',
+          },
+          {
+            title: 'CLI skill (shelve)',
+            description: 'Shelve CLI workflows, flags, and security rules',
+            href: '/.well-known/skills/shelve/SKILL.md',
+          },
+          {
+            title: 'App skill (shelve-app)',
+            description: 'Shelve platform, tokens, teams, and audit logs',
+            href: '/.well-known/skills/shelve-app/SKILL.md',
+          },
+          {
+            title: 'CLI agents & automation',
+            description: 'Global flags, JSON output, CI patterns',
+            href: '/docs/cli/agents-automation',
+          },
+          {
+            title: 'CLI troubleshooting',
+            description: 'Error codes, exit codes, common fixes',
+            href: '/docs/cli/troubleshooting',
+          },
+        ],
+      },
+      {
         title: 'Blog',
         description: 'Latest posts and insights',
         contentCollection: 'blog',

--- a/apps/lp/skills/shelve-app/SKILL.md
+++ b/apps/lp/skills/shelve-app/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: shelve-app
+description: Use the Shelve web app and API concepts — teams, projects, environments, scoped tokens, audit logs, and encryption — when helping users manage secrets outside the CLI.
+---
+
+# Shelve app & platform
+
+Shelve is a team secrets platform at [shelve.cloud](https://shelve.cloud). The **CLI** (`shelve` skill) syncs secrets locally; this skill covers the **dashboard and API model**.
+
+Official docs: https://shelve.cloud/docs  
+CLI skill: install with `npx skills add https://shelve.cloud` (skill `shelve`)
+
+## Core concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Team** | Workspace boundary; identified by `slug` in CLI config |
+| **Project** | App or repo within a team; maps to `SHELVE_PROJECT` / `shelve.json` `project` |
+| **Environment** | Named set of variables (`development`, `preview`, `production`, …) |
+| **Variable** | Key/value secret; may belong to a group with description |
+
+## Tokens (CLI & API auth)
+
+Create at [app.shelve.cloud/user/tokens](https://app.shelve.cloud/user/tokens):
+
+- Plaintext shown **once** at creation — store in CI secrets as `SHELVE_TOKEN`
+- Scoped: `read` / `write`, optional team/project/environment IDs
+- Optional expiry and IP allowlist
+- Send as `Authorization: Bearer <token>`
+
+**Never** commit tokens, log them, or put them in agent prompts.
+
+## Security model
+
+- Variables encrypted at rest (see [Encryption](/docs/core-features/encryption))
+- [Audit logs](/docs/core-features/audit-logs) record token usage and changes
+- Prefer **CLI `shelve run`** for agents — avoids writing `.env` to disk
+- Run **`shelve init`** in repos so agents ignore secret files
+
+## Typical user flows
+
+### New developer on a project
+
+1. Receive team invite / access in Shelve UI
+2. Create scoped CLI token (read + write for their team/project if needed)
+3. `export SHELVE_TOKEN=…` + `SHELVE_TEAM_SLUG` + `SHELVE_PROJECT`
+4. `shelve init` in repo
+5. `shelve run -- pnpm dev`
+
+### CI pipeline
+
+1. Store `SHELVE_TOKEN` in CI secrets (scoped to `ci` environment if possible)
+2. Use [GitHub Action `shelve-run`](https://github.com/HugoRCD/shelve/tree/main/.github/actions/shelve-run) or `npx @shelve/cli run -- …`
+3. Run `shelve doctor --json` in a setup step to fail fast
+
+### Rotating a compromised secret
+
+1. Update variable in Shelve UI (or `shelve push` from trusted machine)
+2. Restart apps / CI — `shelve run --watch` picks up changes for long-running dev servers
+
+## When to use CLI vs UI
+
+| Task | Tool |
+|------|------|
+| Local dev with secrets | CLI `shelve run` |
+| Bulk edit / review variables | Shelve UI |
+| Create scoped CI token | Shelve UI |
+| Audit who changed what | Shelve UI audit logs |
+| Agent-safe workspace setup | CLI `shelve init` |
+
+## Related documentation
+
+- [Environments](/docs/core-features/environments)
+- [API Tokens](/docs/core-features/tokens)
+- [Audit logs](/docs/core-features/audit-logs)
+- [CLI agents & automation](/docs/cli/agents-automation)
+- [CLI troubleshooting](/docs/cli/troubleshooting)

--- a/apps/lp/skills/shelve/SKILL.md
+++ b/apps/lp/skills/shelve/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: shelve
+description: Manage secrets with Shelve and @shelve/cli — inject env vars with shelve run, sync with push/pull, secure AI workspaces with init, and use --json/--non-interactive for automation.
+---
+
+# Shelve CLI & secrets
+
+Shelve is a team secrets platform. The **`@shelve/cli`** package (`shelve` binary) syncs environment variables between your machine and Shelve.
+
+Official docs: https://shelve.cloud/docs/cli  
+Install skill updates: `npx skills add https://shelve.cloud`
+
+## Security rules (read first)
+
+1. **Prefer `shelve run -- <cmd>`** — secrets stay in the child process environment; nothing is written to `.env` on disk.
+2. **Avoid `shelve pull` in agent shells** — it writes plaintext secrets to disk. Agents can exfiltrate them. If you must pull, pass `--yes` explicitly and ensure `.cursorignore` / agent ignores exist (`shelve init`).
+3. **Never commit** `SHELVE_TOKEN`, `.env`, or cache files under `~/.shelve/`.
+4. **Never print secret values** in logs, JSON, or commit messages. CLI `--json` output excludes values by design.
+5. Run **`shelve init`** once per workspace before any secret operations.
+
+## Non-interactive setup
+
+Set these environment variables so the CLI never prompts:
+
+| Variable | Purpose |
+|----------|---------|
+| `SHELVE_TOKEN` | API token from app.shelve.cloud/user/tokens |
+| `SHELVE_TEAM_SLUG` | Team slug |
+| `SHELVE_PROJECT` | Project name |
+| `SHELVE_DEFAULT_ENV` | Default environment (optional) |
+| `SHELVE_URL` | Instance URL (default `https://app.shelve.cloud`) |
+
+Global flags (usable before or after the subcommand):
+
+| Flag | Effect |
+|------|--------|
+| `--json` | Machine-readable stdout; errors as JSON on stderr |
+| `--quiet` / `-q` | No spinners or clack UI |
+| `--yes` / `-y` | Skip confirmations |
+| `--non-interactive` | Fail instead of prompt |
+| `--debug` | Verbose logs (`SHELVE_DEBUG=1` also works) |
+
+Auto non-interactive when: `CI=true`, AI agent shell detected, or `AI_AGENT` is set.
+
+## Command cheat sheet
+
+```bash
+# Inject secrets and run (preferred)
+shelve run -- pnpm dev
+shelve run --env preview -- pnpm build
+shelve run dev                    # resolves package.json script directly
+
+# One-time workspace hardening
+shelve init
+
+# Auth
+shelve login --token "$SHELVE_TOKEN"
+shelve me --json
+shelve logout
+
+# Sync (human workflows; use --env)
+shelve push --env development --yes
+shelve pull --env development --yes   # dangerous in agent shells without --yes
+
+# Inspect config
+shelve --json config                # token shown as ***
+
+# Scaffold
+shelve create --name my-app --slug my-team
+shelve generate --type env-example
+shelve generate --type eslint
+```
+
+## `shelve run` flags
+
+| Flag | Purpose |
+|------|---------|
+| `--env` | Environment name |
+| `--template` | Path to `.env.template` with `shelve://` references |
+| `--offline` | Use encrypted cache only (no API) |
+| `--no-cache` | Disable cache read/write |
+| `--cache-ttl` | Cache freshness (`15m`, `2h`, `1d`; default 24h) |
+| `--watch` | Poll Shelve; reload child on change |
+| `--restart-on-change` | With `--watch`, respawn child instead of SIGHUP |
+
+## Error codes (JSON / automation)
+
+| Code | Meaning |
+|------|---------|
+| `AGENT_BLOCKED` | `pull` refused in agent shell without `--yes` |
+| `AUTH_REQUIRED` | Missing token; set `SHELVE_TOKEN` or `login --token` |
+| `MISSING_ENV` | Pass `--env` or set `defaultEnv` / `SHELVE_DEFAULT_ENV` |
+| `MISSING_INPUT` | Required flag missing in non-interactive mode |
+| `FETCH_FAILED` | `run` could not fetch secrets and cache unavailable |
+
+## Configuration file
+
+`shelve.json` in the project root (merged with monorepo root config):
+
+```json
+{
+  "$schema": "https://shelve.cloud/schema.json",
+  "slug": "my-team",
+  "project": "my-app",
+  "defaultEnv": "development",
+  "confirmChanges": false,
+  "autoCreateProject": true
+}
+```
+
+## When to read reference files
+
+- **`cli-commands.md`** — full command list, JSON shapes, exit codes
+- **`agent-workflows.md`** — CI, monorepo, and AI agent patterns
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `shelve pull` in Cursor/Claude | Use `shelve run -- <cmd>` |
+| CLI hangs waiting for input | Set `SHELVE_*` env vars + `--non-interactive` |
+| `shelve run dev` exits instantly | Use `shelve run -- pnpm dev` or `--debug` |
+| Secrets in git | Run `shelve init`; never commit `.env` |

--- a/apps/lp/skills/shelve/SKILL.md
+++ b/apps/lp/skills/shelve/SKILL.md
@@ -20,6 +20,8 @@ Install skill updates: `npx skills add https://shelve.cloud`
 
 ## Non-interactive setup
 
+Run **`shelve doctor --json`** first in automation to fail fast.
+
 Set these environment variables so the CLI never prompts:
 
 | Variable | Purpose |
@@ -62,7 +64,8 @@ shelve logout
 shelve push --env development --yes
 shelve pull --env development --yes   # dangerous in agent shells without --yes
 
-# Inspect config
+# Inspect / validate
+shelve doctor --json
 shelve --json config                # token shown as ***
 
 # Scaffold

--- a/apps/lp/skills/shelve/agent-workflows.md
+++ b/apps/lp/skills/shelve/agent-workflows.md
@@ -1,0 +1,95 @@
+# Shelve — agent & CI workflows
+
+## Default agent workflow
+
+```bash
+export SHELVE_TOKEN="…"
+export SHELVE_TEAM_SLUG="my-team"
+export SHELVE_PROJECT="my-app"
+
+shelve init
+shelve run -- pnpm test
+shelve run -- pnpm dev
+```
+
+Do **not** run `shelve pull` unless the user explicitly needs a on-disk `.env` file.
+
+## GitHub Actions
+
+```yaml
+env:
+  SHELVE_TOKEN: ${{ secrets.SHELVE_TOKEN }}
+  SHELVE_TEAM_SLUG: my-team
+  SHELVE_PROJECT: my-app
+  SHELVE_DEFAULT_ENV: ci
+
+steps:
+  - run: pnpm install
+  - run: npx @shelve/cli run -- pnpm test
+```
+
+Use `--non-interactive` in CI (also enabled automatically when `CI=true`).
+
+## Parsing CLI output in scripts
+
+```bash
+CONFIG=$(shelve --json config)
+PROJECT=$(echo "$CONFIG" | jq -r '.data.project')
+```
+
+Errors go to stderr as JSON when `--json` is set. Check exit code `$?`.
+
+## Monorepo
+
+- Each package can have its own `shelve.json` with a different `project`.
+- Root `shelve.json` is **merged** (shared `slug`, etc.).
+- Commands run in the **current working directory** only — they do not iterate all packages automatically.
+
+## Offline / air-gapped
+
+After one successful online fetch:
+
+```bash
+shelve run --offline -- pnpm build
+```
+
+Cache lives at `~/.shelve/cache/` (encrypted with key derived from token). Revoking the token invalidates cache.
+
+## Secret references (committed templates)
+
+Commit `.env.template`:
+
+```bash
+DATABASE_URL=shelve://DATABASE_URL
+API_KEY=shelve://production/API_KEY
+```
+
+Run with:
+
+```bash
+shelve run --template .env.template -- pnpm dev
+```
+
+## Watch mode (long-running dev)
+
+```bash
+# SIGHUP reload (daemons that re-read env on SIGHUP)
+shelve run --watch -- pnpm dev
+
+# Full respawn (Node scripts that read process.env once)
+shelve run --watch --restart-on-change -- pnpm dev
+```
+
+## When user asks to "add env vars locally"
+
+1. Ask if they need a disk `.env` or runtime injection.
+2. If runtime → `shelve run -- <cmd>`.
+3. If disk → warn about agent risk, ensure `shelve init`, then `shelve pull --yes --env …` only if they confirm.
+
+## Install / update this skill
+
+```bash
+npx skills add https://shelve.cloud
+```
+
+Catalog: `https://shelve.cloud/.well-known/skills/index.json`

--- a/apps/lp/skills/shelve/agent-workflows.md
+++ b/apps/lp/skills/shelve/agent-workflows.md
@@ -12,7 +12,7 @@ shelve run -- pnpm test
 shelve run -- pnpm dev
 ```
 
-Do **not** run `shelve pull` unless the user explicitly needs a on-disk `.env` file.
+Do **not** run `shelve pull` unless the user explicitly needs an on-disk `.env` file.
 
 ## GitHub Actions
 

--- a/apps/lp/skills/shelve/cli-commands.md
+++ b/apps/lp/skills/shelve/cli-commands.md
@@ -5,6 +5,7 @@
 | Command | Purpose |
 |---------|---------|
 | `run` | Inject secrets into a child process (no `.env` on disk) |
+| `doctor` | Validate config, auth, API, cache, agent context |
 | `init` | Agent ignore files + `.gitignore` shelve block |
 | `login` | Store token (keychain or XDG fallback) |
 | `logout` | Clear stored credentials |

--- a/apps/lp/skills/shelve/cli-commands.md
+++ b/apps/lp/skills/shelve/cli-commands.md
@@ -1,0 +1,145 @@
+# Shelve CLI — command reference
+
+## All commands
+
+| Command | Purpose |
+|---------|---------|
+| `run` | Inject secrets into a child process (no `.env` on disk) |
+| `init` | Agent ignore files + `.gitignore` shelve block |
+| `login` | Store token (keychain or XDG fallback) |
+| `logout` | Clear stored credentials |
+| `me` | Show logged-in user |
+| `push` | Upload local `.env` variables to Shelve |
+| `pull` | Download variables to local `.env` file |
+| `create` | Create Shelve project + `shelve.json` |
+| `config` | Print merged configuration |
+| `generate` | Generate `.env.example` or ESLint config |
+| `upgrade` | Update `@shelve/cli` to latest npm version |
+
+## Global flags
+
+Apply to every command: `--json`, `--quiet` / `-q`, `--yes` / `-y`, `--non-interactive`, `--debug`.
+
+## JSON success shape
+
+```json
+{ "ok": true, "command": "config", "data": { } }
+```
+
+## JSON error shape (stderr)
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "MISSING_ENV",
+    "message": "Environment name is required.",
+    "hint": "Pass --env or set defaultEnv in shelve.json / SHELVE_DEFAULT_ENV."
+  }
+}
+```
+
+## Per-command JSON `data`
+
+### `config`
+
+Merged config object. `token` is always `"***"` when present.
+
+### `me`
+
+```json
+{ "loggedIn": true, "username": "…", "email": "…" }
+```
+
+or `{ "loggedIn": false }`.
+
+### `push`
+
+```json
+{ "env": "development", "variableCount": 12, "pushed": true }
+```
+
+### `pull`
+
+```json
+{
+  "env": "development",
+  "variableCount": 12,
+  "file": ".env",
+  "keys": ["DATABASE_URL", "API_KEY"]
+}
+```
+
+Values are **never** included.
+
+### `init`
+
+```json
+{
+  "writtenFiles": [".cursorignore", ".aiderignore"],
+  "skippedFiles": [],
+  "gitignoreUpdated": true
+}
+```
+
+### `login`
+
+```json
+{ "username": "…", "email": "…" }
+```
+
+### `create`
+
+```json
+{ "name": "my-app", "slug": "my-team", "configPath": "shelve.json" }
+```
+
+### `generate`
+
+```json
+{ "type": "env-example", "path": ".env.example" }
+```
+
+Types: `env-example`, `eslint` (via `--type`).
+
+### `upgrade`
+
+```json
+{ "previous": "5.0.3", "current": "latest", "updated": true }
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error |
+| 128+n | Child signal exit (`run`) |
+| 129 | Parent gone / EIO |
+| 130 / 143 | SIGINT / SIGTERM |
+
+## Environment variables
+
+| Variable | Overrides |
+|----------|-----------|
+| `SHELVE_TOKEN` | Auth token |
+| `SHELVE_TEAM_SLUG` | `slug` in config |
+| `SHELVE_PROJECT` | `project` in config |
+| `SHELVE_URL` | Shelve instance URL |
+| `SHELVE_DEFAULT_ENV` | Default `--env` |
+| `SHELVE_DEBUG=1` | Debug logging |
+| `AI_AGENT` | Force agent-shell detection |
+
+## Config options (`shelve.json`)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `project` | package.json name | Project name |
+| `slug` | — | Team slug |
+| `defaultEnv` | — | Default environment |
+| `confirmChanges` | `false` | Confirm before push/pull file writes |
+| `envFileName` | `.env` | Local env file name |
+| `autoUppercase` | `true` | Uppercase keys on push |
+| `autoCreateProject` | `true` | Create project if missing |
+
+Schema: https://shelve.cloud/schema.json

--- a/docs/agents/cli.md
+++ b/docs/agents/cli.md
@@ -1,0 +1,102 @@
+# Shelve CLI — agents & automation
+
+Use this guide when driving `@shelve/cli` from scripts, CI, or AI agents inside the Shelve monorepo.
+
+**Public documentation:** [shelve.cloud/docs/cli/agents-automation](https://shelve.cloud/docs/cli/agents-automation)
+
+**Install the agent skill** (published via Docus at `/.well-known/skills/`):
+
+```bash
+npx skills add https://shelve.cloud
+```
+
+Catalog: `https://shelve.cloud/.well-known/skills/index.json`
+
+## Recommended workflow
+
+1. Set credentials and project context with environment variables (no prompts):
+   - `SHELVE_TOKEN`
+   - `SHELVE_TEAM_SLUG`
+   - `SHELVE_PROJECT`
+   - `SHELVE_DEFAULT_ENV` (optional)
+   - `SHELVE_URL` (optional, defaults to `https://app.shelve.cloud`)
+2. Run **`shelve init`** once per workspace (writes agent ignore files).
+3. Prefer **`shelve run -- <cmd>`** so secrets stay in memory — avoid **`shelve pull`** in agent shells.
+4. Use **`--json`** when you need machine-readable output.
+5. Use **`--non-interactive`** (or rely on agent/CI auto-detection) so missing flags fail fast instead of hanging on prompts.
+
+## Global flags
+
+These flags can appear before or after the subcommand (parsed from `process.argv`):
+
+| Flag | Alias | Effect |
+|------|-------|--------|
+| `--json` | | Success → JSON on stdout `{ ok, command?, data? }`. Errors → JSON on stderr `{ ok: false, error: { code, message, status?, hint? } }`. |
+| `--quiet` | `-q` | No clack intro/outro/spinners. |
+| `--yes` | `-y` | Skip confirmation prompts (`pull`, `push`, etc.). |
+| `--non-interactive` | | Fail with `MISSING_*` / `AUTH_REQUIRED` instead of prompting. |
+| `--debug` | | Verbose logs (`SHELVE_DEBUG=1`, `DEBUG=true` also work). |
+
+Auto non-interactive when:
+
+- `CI=true` / `CI=1`
+- `std-env` detects an agent shell (`cursor`, `claude`, …)
+- `AI_AGENT` is set
+
+## Command-specific flags
+
+| Command | Flags |
+|---------|-------|
+| `login` | `--token` or `SHELVE_TOKEN` |
+| `push` / `pull` | `--env`, `--yes` |
+| `create` | `--name`, `--slug` |
+| `generate` | `--type env-example \| eslint` |
+| `init` | `--cwd` |
+| `run` | `--env`, `--template`, `--offline`, `--no-cache`, `--cache-ttl`, `--watch`, `--restart-on-change` |
+
+## JSON output (no secret values)
+
+| Command | `data` shape |
+|---------|----------------|
+| `config` | merged config, token redacted as `***` |
+| `me` | `{ loggedIn, username?, email? }` |
+| `push` / `pull` | `{ env, variableCount, pushed?, file?, keys? }` — never includes values |
+| `init` | `{ writtenFiles, skippedFiles, gitignoreUpdated }` |
+| `login` | `{ username, email }` |
+| `create` | `{ name, slug, configPath }` |
+| `logout` | `{ loggedOut: true }` |
+| `generate` | `{ type, path }` |
+| `upgrade` | `{ previous, current, updated }` |
+
+`run` keeps the child process stdio inherited; only startup errors are structured.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | CLI / API / config error |
+| `128 + n` | Child signal (`run`) |
+| `129` | Parent gone / stdin EIO |
+| `130` / `143` | SIGINT / SIGTERM |
+
+## Examples
+
+```bash
+shelve --json config
+shelve --non-interactive --yes push --env staging
+SHELVE_TOKEN=… shelve run -- pnpm dev
+```
+
+## Local testing
+
+```bash
+pnpm play
+pnpm play -- --json config
+```
+
+See [`playground/run/README.md`](../../playground/run/README.md).
+
+## Skill source in this repo
+
+The published skill lives at [`apps/lp/skills/shelve/`](../../apps/lp/skills/shelve/) and is served by Docus at build time.

--- a/docs/agents/cli.md
+++ b/docs/agents/cli.md
@@ -14,7 +14,8 @@ Catalog: `https://shelve.cloud/.well-known/skills/index.json`
 
 ## Recommended workflow
 
-1. Set credentials and project context with environment variables (no prompts):
+1. Run **`shelve doctor --json`** to validate config, auth, API, and cache.
+2. Set credentials and project context with environment variables (no prompts):
    - `SHELVE_TOKEN`
    - `SHELVE_TEAM_SLUG`
    - `SHELVE_PROJECT`
@@ -58,6 +59,7 @@ Auto non-interactive when:
 
 | Command | `data` shape |
 |---------|----------------|
+| `doctor` | `{ healthy, checks[], exitCodes, errorCodes }` |
 | `config` | merged config, token redacted as `***` |
 | `me` | `{ loggedIn, username?, email? }` |
 | `push` / `pull` | `{ env, variableCount, pushed?, file?, keys? }` — never includes values |
@@ -68,7 +70,7 @@ Auto non-interactive when:
 | `generate` | `{ type, path }` |
 | `upgrade` | `{ previous, current, updated }` |
 
-`run` keeps the child process stdio inherited; only startup errors are structured.
+`run` keeps the child process stdio inherited. Startup errors are structured on stderr; with `--json`, a spawn event is also emitted on stderr: `{ ok: true, event: "child_spawned", env, variableCount, keys, command, pid }`.
 
 ## Exit codes
 

--- a/docs/agents/cli.md
+++ b/docs/agents/cli.md
@@ -21,10 +21,10 @@ Catalog: `https://shelve.cloud/.well-known/skills/index.json`
    - `SHELVE_PROJECT`
    - `SHELVE_DEFAULT_ENV` (optional)
    - `SHELVE_URL` (optional, defaults to `https://app.shelve.cloud`)
-2. Run **`shelve init`** once per workspace (writes agent ignore files).
-3. Prefer **`shelve run -- <cmd>`** so secrets stay in memory — avoid **`shelve pull`** in agent shells.
-4. Use **`--json`** when you need machine-readable output.
-5. Use **`--non-interactive`** (or rely on agent/CI auto-detection) so missing flags fail fast instead of hanging on prompts.
+3. Run **`shelve init`** once per workspace (writes agent ignore files).
+4. Prefer **`shelve run -- <cmd>`** so secrets stay in memory — avoid **`shelve pull`** in agent shells.
+5. Use **`--json`** when you need machine-readable output.
+6. Use **`--non-interactive`** (or rely on agent/CI auto-detection) so missing flags fail fast instead of hanging on prompts.
 
 ## Global flags
 

--- a/docs/agents/docs-links.md
+++ b/docs/agents/docs-links.md
@@ -1,6 +1,8 @@
 # Reference Docs
 
-- [Nuxt UI](https://ui.nuxt.com/)
+- [Shelve CLI (public docs)](https://shelve.cloud/docs/cli)
+- [Shelve CLI — agents & automation](https://shelve.cloud/docs/cli/agents-automation)
+- [Shelve agent skill catalog](https://shelve.cloud/.well-known/skills/index.json) — install with `npx skills add https://shelve.cloud`
 - [NuxtHub module](https://nuxt.com/modules/hub)
 - [NuxtHub installation](https://hub.nuxt.com/docs/getting-started/installation)
 - [NuxtHub DB](https://hub.nuxt.com/docs/database)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "play:start": "pnpm -C packages/cli stub && node playground/run/start.mjs run start",
     "play:fail": "pnpm -C packages/cli stub && node playground/run/start.mjs run fail",
     "play:watch": "pnpm -C packages/cli stub && node playground/run/start.mjs run dev --watch --restart-on-change",
+    "play:json": "pnpm -C packages/cli stub && node playground/run/start.mjs --json config",
     "play:server": "node playground/run/server.mjs",
     "db:generate": "pnpm --filter @shelve/app db:generate",
     "db:migrate": "pnpm --filter @shelve/app db:migrate"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -43,29 +43,51 @@ If you are using a monorepo, Shelve will automatically detect the root of the mo
 
 ## Usage
 
-```bash
-Shelve CLI (shelve v4.0.0)
+Global flags (usable before or after the subcommand):
 
-USAGE shelve push|pull|login|logout|me|create|config|generate|upgrade
+- `--json` — machine-readable stdout / structured stderr errors
+- `--quiet` / `-q` — minimal output (no spinners)
+- `--yes` / `-y` — skip confirmations
+- `--non-interactive` — fail instead of prompting (also auto-enabled in CI / AI agent shells)
+- `--debug` — verbose logging (`SHELVE_DEBUG=1`)
+
+See [CLI agents & automation](https://shelve.cloud/docs/cli/agents-automation) on shelve.cloud for the full contract (JSON shapes, exit codes, env vars). Install the agent skill: `npx skills add https://shelve.cloud`.
+
+```bash
+Shelve CLI (shelve v5)
+
+USAGE shelve run|push|pull|login|logout|me|init|create|config|generate|upgrade
 
 COMMANDS
 
+       run    Inject secrets into a child process (no .env on disk)
       push    Push variables for specified environment to Shelve
-      pull    Pull variables for specified environment to Shelve
-     login    Login to Shelve                                   
-    logout    Logout from Shelve locally                        
-        me    Show the currently logged-in user                 
-    create    Create a new project and its config               
-    config    Show the current configuration                    
-  generate    Generate resources for a project                  
-   upgrade    Upgrade the Shelve CLI to the latest version      
+      pull    Pull variables for specified environment from Shelve
+     login    Login to Shelve
+    logout    Logout from Shelve locally
+        me    Show the currently logged-in user
+      init    Add agent ignore files and shelve-managed .gitignore block
+    create    Create a new project and its config
+    config    Show the current configuration
+  generate    Generate resources for a project
+   upgrade    Upgrade the Shelve CLI to the latest version
 
 Use shelve <command> --help for more information about a command.
 ```
 
+### Agents & automation
+
+Prefer `shelve run -- <cmd>` over `shelve pull`. Set `SHELVE_TOKEN`, `SHELVE_TEAM_SLUG`, and `SHELVE_PROJECT` for non-interactive use. Example:
+
+```bash
+shelve --json config
+shelve --non-interactive --yes push --env staging
+shelve run -- pnpm dev
+```
+
 ### Monorepo usage
 
-If you are using a monorepo, running a command at the root level will execute the command for all the projects in the monorepo that have a `shelve.json` file.
+In a monorepo, local `shelve.json` is merged with the root config (shared team slug, etc.). Commands run in the current package directory; they do not automatically iterate all packages.
 
 <!-- automd:fetch url="gh:hugorcd/markdown/main/src/local_development.md" -->
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,7 +56,7 @@ See [CLI agents & automation](https://shelve.cloud/docs/cli/agents-automation) o
 ```bash
 Shelve CLI (shelve v5)
 
-USAGE shelve run|push|pull|login|logout|me|init|create|config|generate|upgrade
+USAGE shelve run|push|pull|login|logout|me|init|create|config|generate|upgrade|doctor
 
 COMMANDS
 
@@ -67,6 +67,7 @@ COMMANDS
     logout    Logout from Shelve locally
         me    Show the currently logged-in user
       init    Add agent ignore files and shelve-managed .gitignore block
+    doctor    Validate CLI setup (config, auth, API, cache)
     create    Create a new project and its config
     config    Show the current configuration
   generate    Generate resources for a project

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'citty'
-import { loadShelveConfig } from '../utils'
+import { isJson, loadShelveConfig, redactConfig } from '../utils'
+import { cliSuccess } from '../utils/output'
 
 export default defineCommand({
   meta: {
@@ -7,6 +8,11 @@ export default defineCommand({
     description: 'Show the current configuration',
   },
   async run() {
-    console.log(await loadShelveConfig(true))
-  }
+    const config = redactConfig(await loadShelveConfig(true))
+    if (isJson()) {
+      cliSuccess(config, undefined, 'config')
+      return
+    }
+    console.log(config)
+  },
 })

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -13,6 +13,6 @@ export default defineCommand({
       cliSuccess(config, undefined, 'config')
       return
     }
-    console.log(config)
+    console.log(JSON.stringify(config, null, 2))
   },
 })

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,6 +1,13 @@
-import { intro, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { askText, createShelveConfig, loadShelveConfig } from '../utils'
+import {
+  askText,
+  cliIntro,
+  cliSuccess,
+  createShelveConfig,
+  isNonInteractive,
+  loadShelveConfig,
+} from '../utils'
+import { CliError } from '../services/api-error'
 import { ProjectService } from '../services'
 
 export default defineCommand({
@@ -16,30 +23,44 @@ export default defineCommand({
     },
     slug: {
       type: 'string',
-      description: 'The slug of the team to which you want the project to belong'
-    }
+      description: 'The slug of the team to which you want the project to belong',
+    },
   },
   async run({ args }) {
     let { name, slug } = args
 
     const { project, slug: teamSlug } = await loadShelveConfig()
 
-    intro(name ? `Creating project '${name}'` : 'Creating a new project')
+    cliIntro(name ? `Creating project '${name}'` : 'Creating a new project')
 
     name = name || project
     slug = slug || teamSlug
 
-    if (!name) name = await askText('Enter the name of the project:', 'my-project', project)
+    if (!name) {
+      if (isNonInteractive()) {
+        throw new CliError('Project name is required.', 'MISSING_PROJECT', undefined, 'Pass --name.')
+      }
+      name = await askText('Enter the name of the project:', 'my-project', project, 'Pass --name.')
+    }
 
-    if (!slug) slug = await askText('Enter the team slug:', 'my-team-slug')
+    if (!slug) {
+      if (isNonInteractive()) {
+        throw new CliError('Team slug is required.', 'MISSING_SLUG', undefined, 'Pass --slug or set SHELVE_TEAM_SLUG.')
+      }
+      slug = await askText('Enter the team slug:', 'my-team-slug', undefined, 'Pass --slug.')
+    }
 
     await ProjectService.createProject(name, slug)
-
-    outro(`Project ${name} created successfully`)
 
     await createShelveConfig({
       projectName: name,
       slug,
     })
-  }
+
+    cliSuccess(
+      { name, slug, configPath: 'shelve.json' },
+      `Project ${name} created successfully`,
+      'create',
+    )
+  },
 })

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,272 @@
+import { existsSync } from 'node:fs'
+import { defineCommand } from 'citty'
+import type { ShelveConfig } from '@types'
+import {
+  cacheFilePath,
+  CacheService,
+  EnvironmentService,
+  ProjectService,
+} from '../services'
+import { BaseService } from '../services/base'
+import { CLI_ERROR_CODES, EXIT_CODES } from '../utils/error-codes'
+import {
+  cliIntro,
+  cliSuccess,
+  cliSuccessLog,
+  cliWarn,
+  isAgentShell,
+  isJson,
+  isNonInteractive,
+  isNonInteractiveExplicit,
+  loadShelveConfig,
+} from '../utils'
+
+export type DoctorCheck = {
+  id: string
+  status: 'ok' | 'warn' | 'error'
+  message: string
+  hint?: string
+}
+
+const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+export default defineCommand({
+  meta: {
+    name: 'doctor',
+    description: 'Validate Shelve CLI setup (config, auth, API, cache) — ideal first step for agents and CI',
+  },
+  args: {
+    env: {
+      type: 'string',
+      description: 'Environment to test (defaults to defaultEnv from config)',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    cliIntro('Checking Shelve CLI setup')
+
+    const checks: DoctorCheck[] = []
+    let config: ShelveConfig
+
+    try {
+      config = await loadShelveConfig(false)
+    } catch (err) {
+      checks.push({
+        id: 'config',
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Failed to load configuration',
+        hint: CLI_ERROR_CODES.CONFIG_MISSING?.hint,
+      })
+      finishDoctor(checks)
+      return
+    }
+
+    pushConfigChecks(config, checks)
+
+    if (!config.token) {
+      finishDoctor(checks)
+      return
+    }
+
+    try {
+      const user = await BaseService.whoAmI(config.url, config.token)
+      checks.push({
+        id: 'auth',
+        status: 'ok',
+        message: `Authenticated as ${user.username} <${user.email}>`,
+      })
+    } catch {
+      checks.push({
+        id: 'auth',
+        status: 'error',
+        message: 'Token is present but authentication failed',
+        hint: CLI_ERROR_CODES.AUTH_REQUIRED?.hint,
+      })
+      finishDoctor(checks)
+      return
+    }
+
+    const envName = args.env || config.defaultEnv
+    if (!config.slug || !config.project) {
+      finishDoctor(checks)
+      return
+    }
+
+    if (!envName) {
+      checks.push({
+        id: 'environment',
+        status: 'warn',
+        message: 'No environment to test (pass --env or set defaultEnv)',
+        hint: CLI_ERROR_CODES.MISSING_ENV?.hint,
+      })
+    } else {
+      await pushApiChecks(config, envName, checks)
+    }
+
+    pushAgentChecks(checks)
+    finishDoctor(checks)
+  },
+})
+
+function pushConfigChecks(config: ShelveConfig, checks: DoctorCheck[]): void {
+  if (!config.slug) {
+    checks.push({
+      id: 'slug',
+      status: 'error',
+      message: 'Team slug is missing',
+      hint: CLI_ERROR_CODES.MISSING_SLUG?.hint,
+    })
+  } else {
+    checks.push({ id: 'slug', status: 'ok', message: `Team slug: ${config.slug}` })
+  }
+
+  if (!config.project) {
+    checks.push({
+      id: 'project',
+      status: 'error',
+      message: 'Project name is missing',
+      hint: CLI_ERROR_CODES.MISSING_PROJECT?.hint,
+    })
+  } else {
+    checks.push({ id: 'project', status: 'ok', message: `Project: ${config.project}` })
+  }
+
+  if (!config.token) {
+    checks.push({
+      id: 'token',
+      status: 'error',
+      message: 'No API token configured',
+      hint: CLI_ERROR_CODES.AUTH_REQUIRED?.hint,
+    })
+  } else {
+    checks.push({ id: 'token', status: 'ok', message: 'API token is configured' })
+  }
+
+  checks.push({
+    id: 'url',
+    status: 'ok',
+    message: `Shelve URL: ${config.url}`,
+  })
+}
+
+async function pushApiChecks(
+  config: ShelveConfig,
+  envName: string,
+  checks: DoctorCheck[],
+): Promise<void> {
+  try {
+    const project = await ProjectService.getProjectByName(
+      config.project,
+      config.slug,
+      config.autoCreateProject,
+    )
+    const environment = await EnvironmentService.getEnvironment(config.slug, envName)
+    checks.push({
+      id: 'environment',
+      status: 'ok',
+      message: `Environment "${environment.name}" is reachable`,
+    })
+
+    const cacheInput = {
+      url: config.url,
+      teamSlug: config.slug,
+      projectName: config.project,
+      environmentName: envName,
+    }
+    const cachePath = cacheFilePath(cacheInput)
+    const cached = config.token
+      ? CacheService.read(cacheInput, config.token, DEFAULT_CACHE_TTL_MS)
+      : null
+
+    if (cached) {
+      checks.push({
+        id: 'cache',
+        status: 'ok',
+        message: `Offline cache hit (${cached.length} variables)`,
+      })
+    } else if (existsSync(cachePath)) {
+      checks.push({
+        id: 'cache',
+        status: 'warn',
+        message: 'Cache file exists but is stale or unreadable with the current token',
+        hint: 'Run `shelve run` online once to refresh the cache.',
+      })
+    } else {
+      checks.push({
+        id: 'cache',
+        status: 'warn',
+        message: 'No offline cache for this project/environment',
+        hint: 'Run `shelve run` online once before using --offline.',
+      })
+    }
+
+    checks.push({
+      id: 'project_api',
+      status: 'ok',
+      message: `Project "${project.name}" resolved (id ${project.id})`,
+    })
+  } catch (err) {
+    checks.push({
+      id: 'api',
+      status: 'error',
+      message: err instanceof Error ? err.message : 'API check failed',
+      hint: 'Run with --debug for HTTP details.',
+    })
+  }
+}
+
+function pushAgentChecks(checks: DoctorCheck[]): void {
+  if (isAgentShell()) {
+    checks.push({
+      id: 'agent',
+      status: 'warn',
+      message: 'AI agent shell detected — prefer `shelve run -- <cmd>` over `shelve pull`',
+      hint: 'See https://shelve.cloud/docs/cli/agents-automation',
+    })
+  }
+
+  if (isNonInteractiveExplicit() || process.env.CI === 'true' || process.env.CI === '1') {
+    checks.push({
+      id: 'non_interactive',
+      status: 'ok',
+      message: 'Non-interactive mode active (CI or --non-interactive)',
+    })
+  } else if (isNonInteractive()) {
+    checks.push({
+      id: 'non_interactive',
+      status: 'ok',
+      message: 'Non-interactive mode active (agent auto-detection)',
+    })
+  }
+}
+
+function finishDoctor(checks: DoctorCheck[]): never | void {
+  const healthy = !checks.some(c => c.status === 'error')
+  const warnCount = checks.filter(c => c.status === 'warn').length
+
+  const data = {
+    healthy,
+    checks,
+    exitCodes: EXIT_CODES,
+    errorCodes: Object.fromEntries(
+      Object.entries(CLI_ERROR_CODES).map(([code, meta]) => [code, meta.meaning]),
+    ),
+  }
+
+  if (isJson()) {
+    cliSuccess(data, undefined, 'doctor')
+  } else {
+    for (const check of checks) {
+      if (check.status === 'ok') cliSuccessLog(`✓ ${check.message}`)
+      else if (check.status === 'warn') cliWarn(`${check.message}${check.hint ? ` — ${check.hint}` : ''}`)
+      else cliWarn(`✗ ${check.message}${check.hint ? ` — ${check.hint}` : ''}`)
+    }
+    if (healthy && warnCount === 0) {
+      cliSuccess(undefined, 'All checks passed', 'doctor')
+    } else if (healthy) {
+      cliSuccess(undefined, `Passed with ${warnCount} warning(s)`, 'doctor')
+    }
+  }
+
+  if (!healthy) process.exit(1)
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -258,7 +258,17 @@ function finishDoctor(checks: DoctorCheck[]): never | void {
     if (healthy) {
       cliSuccess(data, undefined, 'doctor')
     } else {
-      console.error(JSON.stringify({ ok: false, command: 'doctor', data }))
+      const failedCheck = checks.find(c => c.status === 'error')
+      console.error(JSON.stringify({
+        ok: false,
+        command: 'doctor',
+        error: {
+          code: 'DOCTOR_UNHEALTHY',
+          message: failedCheck?.message ?? 'Doctor checks failed',
+          ...(failedCheck?.hint ? { hint: failedCheck.hint } : {}),
+          details: data,
+        },
+      }))
     }
   } else {
     for (const check of checks) {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -103,7 +103,6 @@ export default defineCommand({
       await pushApiChecks(config, envName, checks)
     }
 
-    pushAgentChecks(checks)
     finishDoctor(checks)
   },
 })
@@ -241,6 +240,8 @@ function pushAgentChecks(checks: DoctorCheck[]): void {
 }
 
 function finishDoctor(checks: DoctorCheck[]): never | void {
+  pushAgentChecks(checks)
+
   const healthy = !checks.some(c => c.status === 'error')
   const warnCount = checks.filter(c => c.status === 'warn').length
 
@@ -254,7 +255,11 @@ function finishDoctor(checks: DoctorCheck[]): never | void {
   }
 
   if (isJson()) {
-    cliSuccess(data, undefined, 'doctor')
+    if (healthy) {
+      cliSuccess(data, undefined, 'doctor')
+    } else {
+      console.error(JSON.stringify({ ok: false, command: 'doctor', data }))
+    }
   } else {
     for (const check of checks) {
       if (check.status === 'ok') cliSuccessLog(`✓ ${check.message}`)

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,37 +1,83 @@
-import { intro, isCancel, outro, select } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { getEslintConfig, handleCancel } from '../utils'
+import { getEslintConfig, cliCancel, cliIntro, cliSuccess, handleCancel } from '../utils'
 import { EnvService } from '../services'
+import { CliError } from '../services/api-error'
+import { isNonInteractive } from '../utils/cli-context'
+import { loadShelveConfig } from '../utils/config'
+
+const GENERATE_TYPES = {
+  'env-example': 'example',
+  eslint: 'eslint',
+} as const
+
+type GenerateType = keyof typeof GENERATE_TYPES
 
 export default defineCommand({
   meta: {
     name: 'generate',
     description: 'Generate resources for a project',
   },
-  async run() {
-    intro('Generate resources for a project')
+  args: {
+    type: {
+      type: 'string',
+      description: 'Resource to generate: env-example | eslint',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    cliIntro('Generate resources for a project')
 
-    const toGenerate = await select({
-      message: 'Select the resources to generate:',
-      options: [
-        { value: 'example', label: '.env.example' },
-        { value: 'eslint', label: 'ESLint config' },
-      ]
-    })
-
-    if (isCancel(toGenerate)) handleCancel('Operation cancelled.')
-
-    switch (toGenerate) {
-      case 'example':
-        await EnvService.generateEnvExampleFile()
-        break
-      case 'eslint':
-        await getEslintConfig()
-        break
-      default:
-        handleCancel('Invalid option')
+    const typeArg = args.type as GenerateType | undefined
+    if (!typeArg) {
+      if (isNonInteractive()) {
+        throw new CliError(
+          'Generate type is required.',
+          'MISSING_INPUT',
+          undefined,
+          'Pass --type env-example or --type eslint.',
+        )
+      }
+      const { select, isCancel } = await import('@clack/prompts')
+      const toGenerate = await select({
+        message: 'Select the resources to generate:',
+        options: [
+          { value: 'example', label: '.env.example' },
+          { value: 'eslint', label: 'ESLint config' },
+        ],
+      })
+      if (isCancel(toGenerate)) handleCancel('Operation cancelled.')
+      await runGenerate(toGenerate as 'example' | 'eslint')
+      return
     }
 
-    outro('Done')
+    const mapped = GENERATE_TYPES[typeArg]
+    if (!mapped) {
+      throw new CliError(
+        `Unknown generate type "${typeArg}".`,
+        'INVALID_INPUT',
+        undefined,
+        'Use --type env-example or --type eslint.',
+      )
+    }
+
+    await runGenerate(mapped, typeArg)
   },
 })
+
+async function runGenerate(internal: 'example' | 'eslint', publicType?: string): Promise<void> {
+  switch (internal) {
+    case 'example': {
+      await EnvService.generateEnvExampleFile()
+      const { envFileName } = await loadShelveConfig()
+      cliSuccess({ type: publicType || 'env-example', path: `${envFileName}.example` }, 'Done', 'generate')
+      break
+    }
+    case 'eslint': {
+      const path = await getEslintConfig()
+      cliSuccess({ type: publicType || 'eslint', path }, 'Done', 'generate')
+      break
+    }
+    default:
+      cliCancel('Invalid option')
+  }
+}

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'citty'
-import { getEslintConfig, cliCancel, cliIntro, cliSuccess, handleCancel } from '../utils'
+import { getEslintConfig, cliIntro, cliSuccess, handleCancel } from '../utils'
 import { EnvService } from '../services'
 import { CliError } from '../services/api-error'
 import { isNonInteractive } from '../utils/cli-context'
@@ -77,7 +77,5 @@ async function runGenerate(internal: 'example' | 'eslint', publicType?: string):
       cliSuccess({ type: publicType || 'eslint', path }, 'Done', 'generate')
       break
     }
-    default:
-      cliCancel('Invalid option')
   }
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { defineCommand } from 'citty'
-import { intro, outro, log } from '@clack/prompts'
-import { writeAgentIgnoreFiles } from '../utils'
+import { cliInfo, cliIntro, cliSuccess, cliSuccessLog, writeAgentIgnoreFiles } from '../utils'
 
 const GITIGNORE_BLOCK = [
   '# shelve-managed-block',
@@ -27,28 +26,34 @@ export default defineCommand({
     },
   },
   run({ args }) {
-    intro('Securing this workspace from AI agents')
+    cliIntro('Securing this workspace from AI agents')
 
     const cwd = args.cwd || process.cwd()
     const { writtenFiles, skippedFiles } = writeAgentIgnoreFiles(cwd)
 
     if (writtenFiles.length > 0) {
-      log.success(`Updated: ${writtenFiles.join(', ')}`)
+      cliSuccessLog(`Updated: ${writtenFiles.join(', ')}`)
     }
     if (skippedFiles.length > 0) {
-      log.info(`Already up to date: ${skippedFiles.join(', ')}`)
+      cliInfo(`Already up to date: ${skippedFiles.join(', ')}`)
     }
 
     const gitignorePath = join(cwd, '.gitignore')
     const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : ''
+    let gitignoreUpdated = false
     if (!existing.includes('# shelve-managed-block')) {
       const sep = existing.length === 0 ? '' : existing.endsWith('\n') ? '' : '\n'
       writeFileSync(gitignorePath, `${existing + sep + GITIGNORE_BLOCK.join('\n') }\n`, 'utf-8')
-      log.success('Updated: .gitignore')
+      cliSuccessLog('Updated: .gitignore')
+      gitignoreUpdated = true
     } else {
-      log.info('.gitignore already contains a shelve-managed block')
+      cliInfo('.gitignore already contains a shelve-managed block')
     }
 
-    outro('Use `shelve run -- <cmd>` instead of `shelve pull` whenever possible.')
+    cliSuccess(
+      { writtenFiles, skippedFiles, gitignoreUpdated },
+      'Use `shelve run -- <cmd>` instead of `shelve pull` whenever possible.',
+      'init',
+    )
   },
 })

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,21 +1,32 @@
-import { intro, outro } from '@clack/prompts'
-import type { User } from '@types'
 import { defineCommand } from 'citty'
+import type { User } from '@types'
 import { loadShelveConfig } from '../utils'
 import { BaseService } from '../services/base'
+import { cliIntro, cliSuccess } from '../utils/output'
 
 export default defineCommand({
   meta: {
     name: 'login',
-    description: 'Login to Shelve'
+    description: 'Login to Shelve',
   },
-  async run() {
+  args: {
+    token: {
+      type: 'string',
+      description: 'API token (or set SHELVE_TOKEN)',
+      required: false,
+    },
+  },
+  async run({ args }) {
     const { url } = await loadShelveConfig()
 
-    intro(`Login to Shelve on ${url}`)
+    cliIntro(`Login to Shelve on ${url}`)
 
-    const { user } = await BaseService.getToken(true) as { user: User }
+    const { user } = await BaseService.getToken(true, args.token) as { user: User, token: string }
 
-    outro(`Successfully logged in as ${user.username}`)
-  }
+    cliSuccess(
+      { username: user.username, email: user.email },
+      `Successfully logged in as ${user.username}`,
+      'login',
+    )
+  },
 })

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -1,7 +1,6 @@
-import { intro, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { CredentialsService } from '../services'
-import { loadShelveConfig } from '../utils'
+import { cliIntro, cliSuccess, loadShelveConfig } from '../utils'
 
 export default defineCommand({
   meta: {
@@ -9,9 +8,9 @@ export default defineCommand({
     description: 'Logout from Shelve locally',
   },
   async run() {
-    intro('Logging out')
+    cliIntro('Logging out')
     const { url } = await loadShelveConfig()
     await CredentialsService.clearToken(url)
-    outro('Successfully logged out')
+    cliSuccess({ loggedOut: true }, 'Successfully logged out', 'logout')
   },
 })

--- a/packages/cli/src/commands/me.ts
+++ b/packages/cli/src/commands/me.ts
@@ -1,20 +1,24 @@
-import { note } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { CredentialsService } from '../services/credentials'
+import { cliSuccess } from '../utils/output'
 
 export default defineCommand({
   meta: {
     name: 'me',
-    description: 'Show the currently logged-in user'
+    description: 'Show the currently logged-in user',
   },
   run() {
     const config = CredentialsService.readMeta()
 
     if (!config.email && !config.username) {
-      note('You are not logged in')
+      cliSuccess({ loggedIn: false }, 'You are not logged in', 'me')
       return
     }
 
-    note(`You are logged in as ${config.username} <${config.email}>`, 'Current user')
-  }
+    cliSuccess(
+      { loggedIn: true, username: config.username, email: config.email },
+      `You are logged in as ${config.username} <${config.email}>`,
+      'me',
+    )
+  },
 })

--- a/packages/cli/src/commands/me.ts
+++ b/packages/cli/src/commands/me.ts
@@ -15,9 +15,13 @@ export default defineCommand({
       return
     }
 
+    const displayParts: string[] = []
+    if (config.username) displayParts.push(config.username)
+    if (config.email) displayParts.push(`<${config.email}>`)
+
     cliSuccess(
       { loggedIn: true, username: config.username, email: config.email },
-      `You are logged in as ${config.username} <${config.email}>`,
+      displayParts.length ? `You are logged in as ${displayParts.join(' ')}` : 'You are logged in',
       'me',
     )
   },

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,7 +1,7 @@
-import { intro, outro, log, confirm, isCancel } from '@clack/prompts'
+import { confirm, isCancel } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { agent as detectedAgent } from 'std-env'
-import { handleCancel, loadShelveConfig } from '../utils'
+import { isAgentShell, loadShelveConfig, shouldSkipConfirm } from '../utils'
+import { cliCancel, cliError, cliIntro, cliSuccess, cliWarn } from '../utils/output'
 import { EnvService, ProjectService, EnvironmentService } from '../services'
 
 export default defineCommand({
@@ -31,15 +31,26 @@ export default defineCommand({
       defaultEnv,
     } = await loadShelveConfig(true)
 
-    if (detectedAgent && !args.yes) {
-      log.warn(
-        `${detectedAgent} appears to be running in this shell. \`shelve pull\` writes plaintext secrets to ${envFileName} where AI agents can read them. Prefer \`shelve run -- <cmd>\` so secrets stay in memory.`
-      )
-      const proceed = await confirm({ message: 'Write secrets to disk anyway?', initialValue: false })
-      if (isCancel(proceed) || !proceed) handleCancel('Aborted by user')
+    const skipConfirm = args.yes || shouldSkipConfirm()
+
+    if (isAgentShell() && !skipConfirm) {
+      cliError({
+        code: 'AGENT_BLOCKED',
+        message: `\`shelve pull\` writes plaintext secrets to ${envFileName} where AI agents can read them.`,
+        hint: 'Prefer `shelve run -- <cmd>` so secrets stay in memory, or pass --yes to write secrets to disk anyway.',
+      })
     }
 
-    intro(`Pulling variable from ${project} project`)
+    if (isAgentShell() && skipConfirm) {
+      cliWarn(
+        `${process.env.AI_AGENT || 'AI agent'} detected. Writing secrets to ${envFileName}. Prefer \`shelve run -- <cmd>\` when possible.`
+      )
+    } else if (!skipConfirm && !isAgentShell()) {
+      const proceed = await confirm({ message: 'Write secrets to disk?', initialValue: false })
+      if (isCancel(proceed) || !proceed) cliCancel('Aborted by user')
+    }
+
+    cliIntro(`Pulling variable from ${project} project`)
 
     const projectData = await ProjectService.getProjectByName(project, slug, autoCreateProject)
 
@@ -49,11 +60,23 @@ export default defineCommand({
 
     const variables = await EnvService.getEnvVariables({ project: projectData, environmentId: environment.id, slug })
 
-    if (variables.length === 0)
-      log.warn('No variables found in the specified environment')
-    else
-      await EnvService.createEnvFile({ envFileName, variables, confirmChanges })
+    const effectiveConfirmChanges = skipConfirm ? false : confirmChanges
 
-    outro(`Successfully pulled variable from ${environment.name} environment`)
+    if (variables.length === 0) {
+      cliWarn('No variables found in the specified environment')
+    } else {
+      await EnvService.createEnvFile({ envFileName, variables, confirmChanges: effectiveConfirmChanges })
+    }
+
+    cliSuccess(
+      {
+        env: environment.name,
+        variableCount: variables.length,
+        file: envFileName,
+        keys: variables.map(v => v.key),
+      },
+      `Successfully pulled variable from ${environment.name} environment`,
+      'pull',
+    )
   },
 })

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'citty'
-import { loadShelveConfig, shouldSkipConfirm } from '../utils'
+import { loadShelveConfig } from '../utils'
 import { isNonInteractive } from '../utils/cli-context'
 import { cliIntro, cliSuccess } from '../utils/output'
 import { CliError } from '../services/api-error'
@@ -32,7 +32,7 @@ export default defineCommand({
       defaultEnv,
     } = await loadShelveConfig(true)
 
-    const confirmed = args.yes || shouldSkipConfirm()
+    const confirmed = Boolean(args.yes)
     if (confirmChanges && !confirmed && isNonInteractive()) {
       throw new CliError(
         'Push confirmation is required.',

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,6 +1,8 @@
 import { defineCommand } from 'citty'
 import { loadShelveConfig, shouldSkipConfirm } from '../utils'
+import { isNonInteractive } from '../utils/cli-context'
 import { cliIntro, cliSuccess } from '../utils/output'
+import { CliError } from '../services/api-error'
 import { EnvService, ProjectService, EnvironmentService } from '../services'
 
 export default defineCommand({
@@ -30,8 +32,16 @@ export default defineCommand({
       defaultEnv,
     } = await loadShelveConfig(true)
 
-    const skipConfirm = args.yes || shouldSkipConfirm()
-    const effectiveConfirmChanges = skipConfirm ? false : confirmChanges
+    const confirmed = args.yes || shouldSkipConfirm()
+    if (confirmChanges && !confirmed && isNonInteractive()) {
+      throw new CliError(
+        'Push confirmation is required.',
+        'CONFIRMATION_REQUIRED',
+        undefined,
+        'Pass --yes to confirm pushing variables in non-interactive mode.',
+      )
+    }
+    const effectiveConfirmChanges = confirmed ? false : confirmChanges
 
     cliIntro(`Pushing variable to ${project} project`)
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,17 +1,22 @@
-import { intro, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { loadShelveConfig } from '../utils'
-import { EnvironmentService, EnvService, ProjectService } from '../services'
+import { loadShelveConfig, shouldSkipConfirm } from '../utils'
+import { cliIntro, cliSuccess } from '../utils/output'
+import { EnvService, ProjectService, EnvironmentService } from '../services'
 
 export default defineCommand({
   meta: {
     name: 'push',
-    description: 'Push variables for specified environment to Shelve'
+    description: 'Push variables for specified environment to Shelve',
   },
   args: {
     env: {
       type: 'string',
       description: 'Specify the environment to which you want to push the variables',
+      required: false,
+    },
+    yes: {
+      type: 'boolean',
+      description: 'Skip confirmation prompts',
       required: false,
     },
   },
@@ -22,10 +27,13 @@ export default defineCommand({
       confirmChanges,
       autoUppercase,
       autoCreateProject,
-      defaultEnv
+      defaultEnv,
     } = await loadShelveConfig(true)
 
-    intro(`Pushing variable to ${project} project`)
+    const skipConfirm = args.yes || shouldSkipConfirm()
+    const effectiveConfirmChanges = skipConfirm ? false : confirmChanges
+
+    cliIntro(`Pushing variable to ${project} project`)
 
     const projectData = await ProjectService.getProjectByName(project, slug, autoCreateProject)
 
@@ -34,11 +42,27 @@ export default defineCommand({
     const environment = await EnvironmentService.getEnvironment(slug, env)
     const variables = await EnvService.getEnvFile()
 
-    const pushed = await EnvService.pushEnvFile({ variables, project: projectData, environment, confirmChanges, autoUppercase, slug })
+    const pushed = await EnvService.pushEnvFile({
+      variables,
+      project: projectData,
+      environment,
+      confirmChanges: effectiveConfirmChanges,
+      autoUppercase,
+      slug,
+    })
 
-    if (pushed)
-      outro(`Successfully pushed variable to ${environment.name} environment`)
-    else
-      outro('Variable push was cancelled')
-  }
+    if (pushed) {
+      cliSuccess(
+        { env: environment.name, variableCount: variables.length, pushed: true },
+        `Successfully pushed variable to ${environment.name} environment`,
+        'push',
+      )
+    } else {
+      cliSuccess(
+        { env: environment.name, variableCount: variables.length, pushed: false },
+        'Variable push was cancelled',
+        'push',
+      )
+    }
+  },
 })

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -11,6 +11,7 @@ import {
   cliError,
   cliInfo,
   cliIntro,
+  cliJsonEvent,
   cliWarn,
   handleCancel,
   loadShelveConfig,
@@ -156,6 +157,14 @@ export default defineCommand({
     const secretEnv = buildEnv(variables, template, envName)
 
     let child = await spawnChild(argv, secretEnv)
+
+    cliJsonEvent('child_spawned', {
+      env: envName,
+      variableCount: variables.length,
+      keys: variables.map(v => v.key),
+      command: argv.join(' '),
+      pid: child.pid,
+    })
 
     watchParentLiveness((sig) => {
       debugLog(`Parent process gone — tearing down child tree`)

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,12 +3,15 @@ import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import * as os from 'node:os'
 import { defineCommand } from 'citty'
-import { intro, log } from '@clack/prompts'
 import type { EnvVarExport, Project, Environment } from '@types'
 import consola from 'consola'
 import { readPackageJSON } from 'pkg-types'
 import treeKill from 'tree-kill'
 import {
+  cliError,
+  cliInfo,
+  cliIntro,
+  cliWarn,
   handleCancel,
   loadShelveConfig,
   loadTemplate,
@@ -24,6 +27,7 @@ import {
   type CacheKeyInput,
 } from '../services'
 import { debugLog } from '../constants'
+import { formatCliError, toCliError } from '../services/api-error'
 
 const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const WATCH_POLL_MS = 5_000
@@ -93,7 +97,7 @@ export default defineCommand({
     const noCache = runArgs.noCache === true
     const cacheTtl = parseDuration(runArgs.cacheTtl, DEFAULT_CACHE_TTL_MS)
 
-    intro(`Loading secrets for ${project} (${runArgs.env || defaultEnv})`)
+    cliIntro(`Loading secrets for ${project} (${runArgs.env || defaultEnv})`)
 
     const template = runArgs.template ? loadTemplateOrExit(runArgs.template) : null
 
@@ -114,7 +118,7 @@ export default defineCommand({
       const cached = token ? CacheService.read(cacheInput(envName), token, 0) : null
       if (!cached) handleCancel('Offline cache not found for this project/environment.')
       variables = cached!
-      log.info('Using offline cache (network skipped).')
+      cliInfo('Using offline cache (network skipped).')
     } else {
       try {
         projectData = await ProjectService.getProjectByName(project, slug, autoCreateProject)
@@ -127,13 +131,24 @@ export default defineCommand({
         if (!noCache && token) CacheService.write(cacheInput(envName), token, variables)
       } catch (err) {
         if (noCache) {
-          process.exit(1)
+          const apiError = toCliError(err, 'FETCH_FAILED')
+          cliError({
+            code: apiError.code,
+            message: formatCliError(err, 'Failed to fetch secrets from Shelve'),
+            status: apiError.status,
+          })
         }
         const cached = token ? CacheService.read(cacheInput(envName), token, cacheTtl) : null
         if (!cached) {
-          process.exit(1)
+          const apiError = toCliError(err, 'FETCH_FAILED')
+          cliError({
+            code: apiError.code,
+            message: formatCliError(err, 'Failed to fetch secrets from Shelve and no offline cache is available'),
+            status: apiError.status,
+            hint: 'Run `shelve pull` once while online, or pass --offline when a cache exists.',
+          })
         }
-        log.warn('Failed to fetch from Shelve; falling back to encrypted cache.')
+        cliWarn('Failed to fetch from Shelve; falling back to encrypted cache.')
         variables = cached
       }
     }
@@ -150,7 +165,7 @@ export default defineCommand({
 
     if (runArgs.watch) {
       if (!projectData || !environment) {
-        log.warn('Watch mode requires a successful API connection on startup; ignoring --watch.')
+        cliWarn('Watch mode requires a successful API connection on startup; ignoring --watch.')
       } else {
         startWatch({
           projectData,
@@ -211,7 +226,7 @@ function buildEnv(
   const { resolved, missing } = resolveReferences(template, variables, envName)
   for (const { key, value } of resolved) env[key] = value
   if (missing.length > 0) {
-    log.warn(
+    cliWarn(
       `Unresolved secret references (still rendered as the literal placeholder): ${missing.map(m => m.key).join(', ')}`
     )
   }
@@ -430,7 +445,7 @@ function startWatch(opts: WatchOpts): void {
       })
       const fp = fingerprint(next)
       if (lastPrint && fp !== lastPrint) {
-        log.info('Variables changed — reloading child process.')
+        cliInfo('Variables changed — reloading child process.')
         if (!opts.noCache && opts.token) {
           CacheService.write(opts.cacheInput(opts.envName), opts.token, next)
         }

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,26 +1,27 @@
-import { intro, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { isLatestVersion, installLatest, handleCancel } from '../utils'
+import { cliIntro, cliSuccess, isLatestVersion, installLatest } from '../utils'
+import { toCliError } from '../services/api-error'
+import { version } from '../../package.json'
 
 export default defineCommand({
   meta: {
     name: 'upgrade',
-    description: 'Upgrade the Shelve CLI to the latest version'
+    description: 'Upgrade the Shelve CLI to the latest version',
   },
   async run() {
-    intro('Upgrading Shelve CLI to the latest version')
+    cliIntro('Upgrading Shelve CLI to the latest version')
 
     try {
       const isLatest = await isLatestVersion()
       if (isLatest) {
-        outro('Shelve CLI is already up to date')
+        cliSuccess({ previous: version, current: version, updated: false }, 'Shelve CLI is already up to date', 'upgrade')
         return
       }
 
       await installLatest()
-      outro('Shelve CLI has been successfully updated')
+      cliSuccess({ previous: version, current: 'latest', updated: true }, 'Shelve CLI has been successfully updated', 'upgrade')
     } catch (error) {
-      handleCancel('Operation cancelled.')
+      throw toCliError(error, 'UPGRADE_FAILED')
     }
-  }
+  },
 })

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -18,8 +18,8 @@ export default defineCommand({
         return
       }
 
-      await installLatest()
-      cliSuccess({ previous: version, current: 'latest', updated: true }, 'Shelve CLI has been successfully updated', 'upgrade')
+      const latestVersion = await installLatest()
+      cliSuccess({ previous: version, current: latestVersion, updated: true }, 'Shelve CLI has been successfully updated', 'upgrade')
     } catch (error) {
       throw toCliError(error, 'UPGRADE_FAILED')
     }

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,3 +1,13 @@
 export { debugLog, initDebugFromArgv, isDebug, setDebug } from './utils/debug'
+export {
+  GLOBAL_CLI_ARGS,
+  initCliContextFromArgv,
+  isAgentShell,
+  isJson,
+  isNonInteractive,
+  isNonInteractiveExplicit,
+  isQuiet,
+  shouldSkipConfirm,
+} from './utils/cli-context'
 
 export const DEFAULT_ENV_FILENAME = '.env'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,8 @@ import logout from './commands/logout'
 import upgrade from './commands/upgrade'
 import run from './commands/run'
 import init from './commands/init'
+import doctor from './commands/doctor'
+import { formatErrorCodesHelp } from './utils/error-codes'
 
 initDebugFromArgv()
 initCliContextFromArgv()
@@ -42,7 +44,9 @@ function getCliPackageVersion(): string {
 const main = defineCommand({
   meta: {
     name: 'shelve',
-    description: 'Shelve CLI',
+    description: `Shelve CLI — manage team secrets from the terminal.
+
+${formatErrorCodesHelp()}`,
     version: getCliPackageVersion(),
   },
   args: GLOBAL_CLI_ARGS,
@@ -58,6 +62,7 @@ const main = defineCommand({
     logout,
     me,
     init,
+    doctor,
     create,
     config,
     generate,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,9 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineCommand, runMain } from 'citty'
 import consola from 'consola'
-import { initDebugFromArgv, setDebug } from './constants'
+import { GLOBAL_CLI_ARGS, initCliContextFromArgv, initDebugFromArgv, setDebug } from './constants'
+import { CliError } from './services/api-error'
+import { cliError } from './utils/output'
 import push from './commands/push'
 import pull from './commands/pull'
 import config from './commands/config'
@@ -19,6 +21,7 @@ import run from './commands/run'
 import init from './commands/init'
 
 initDebugFromArgv()
+initCliContextFromArgv()
 
 process.stdin.on?.('error', (err: NodeJS.ErrnoException) => {
   if (err && err.code === 'EIO') {
@@ -42,15 +45,10 @@ const main = defineCommand({
     description: 'Shelve CLI',
     version: getCliPackageVersion(),
   },
-  args: {
-    debug: {
-      type: 'boolean',
-      description: 'Enable verbose debug logging (or set SHELVE_DEBUG=1)',
-      default: false,
-    },
-  },
+  args: GLOBAL_CLI_ARGS,
   setup({ args }) {
     if (args.debug) setDebug(true)
+    initCliContextFromArgv()
   },
   subCommands: {
     run,
@@ -70,6 +68,14 @@ const main = defineCommand({
 runMain(main).then((_) => {
   process.exit(0)
 }).catch((err) => {
+  if (err instanceof CliError) {
+    cliError({
+      code: err.code,
+      message: err.message,
+      status: err.status,
+      hint: err.hint,
+    })
+  }
   consola.error(err)
   process.exit(1)
 })

--- a/packages/cli/src/services/api-error.ts
+++ b/packages/cli/src/services/api-error.ts
@@ -10,6 +10,22 @@ export class ShelveApiError extends Error {
 
 }
 
+export class CliError extends Error {
+
+  readonly code: string
+  readonly status?: number
+  readonly hint?: string
+
+  constructor(message: string, code: string, status?: number, hint?: string) {
+    super(message)
+    this.name = 'CliError'
+    this.code = code
+    this.status = status
+    this.hint = hint
+  }
+
+}
+
 export function getHttpStatus(error: unknown): number | undefined {
   if (error instanceof ShelveApiError) return error.status
   if (error && typeof error === 'object') {
@@ -20,10 +36,26 @@ export function getHttpStatus(error: unknown): number | undefined {
 }
 
 export function formatCliError(error: unknown, context?: string): string {
+  if (error instanceof CliError) return error.message
   if (error instanceof ShelveApiError) return error.message
   if (error instanceof Error && error.message) return error.message
   if (context) return `${context} failed`
   return 'Something went wrong'
+}
+
+export function toCliError(error: unknown, fallbackCode = 'OPERATION_FAILED'): CliError {
+  if (error instanceof CliError) return error
+  if (error instanceof ShelveApiError) {
+    const code = error.status === 401 ? 'AUTH_REQUIRED'
+      : error.status === 403 ? 'FORBIDDEN'
+      : error.status === 404 ? 'NOT_FOUND'
+      : 'API_ERROR'
+    return new CliError(error.message, code, error.status)
+  }
+  if (error instanceof Error && error.message) {
+    return new CliError(error.message, fallbackCode)
+  }
+  return new CliError('Something went wrong', fallbackCode)
 }
 
 export function isRecoverableHttpError(error: unknown, statuses: number[]): boolean {

--- a/packages/cli/src/services/base.ts
+++ b/packages/cli/src/services/base.ts
@@ -2,10 +2,11 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { ofetch, type $Fetch, type FetchOptions } from 'ofetch'
-import { spinner } from '@clack/prompts'
 import type { User } from '@types'
+import { debugLog, isDebug } from '../constants'
 import { askPassword, loadShelveConfig } from '../utils'
-import { formatCliError } from './api-error'
+import { withSpinner } from '../utils/output'
+import { toCliError } from './api-error'
 import { ErrorService } from './error'
 import { CredentialsService } from './credentials'
 
@@ -17,26 +18,12 @@ export abstract class BaseService {
 
   protected static api: $Fetch
 
-  protected static async withLoading<T>(
+  protected static withLoading<T>(
     message: string,
     callback: () => Promise<T>,
     options?: LoadingOptions,
   ): Promise<T> {
-    const s = spinner()
-    try {
-      s.start(message)
-      const result = await callback()
-      s.stop(message)
-      return result
-    } catch (error) {
-      if (options?.recoverable?.(error)) {
-        s.stop(message)
-        throw error
-      }
-
-      s.cancel(formatCliError(error, message))
-      throw error
-    }
+    return withSpinner(message, callback, options)
   }
 
   static whoAmI(url: string, token: string): Promise<User> {
@@ -46,21 +33,30 @@ export abstract class BaseService {
         headers: {
           Authorization: `Bearer ${token}`,
         },
+        onRequest({ request, options: reqOptions }) {
+          logHttpRequest(reqOptions.method || 'GET', request.toString())
+        },
+        onResponse({ request, response, options: reqOptions }) {
+          logHttpResponse(reqOptions.method || 'GET', request.toString(), response.status)
+        },
       })
     })
   }
 
-  static async getToken(returnUser: boolean = false): Promise<string | { user: User, token: string }> {
+  static async getToken(returnUser: boolean = false, tokenFromFlag?: string): Promise<string | { user: User, token: string }> {
     const { url } = await loadShelveConfig()
     const sanitizedUrl = url.replace(/\/+$/, '')
-    const token = await askPassword(`Please provide a valid token (you can generate one on ${sanitizedUrl}/user/tokens)`)
+    const token = await askPassword(
+      `Please provide a valid token (you can generate one on ${sanitizedUrl}/user/tokens)`,
+      tokenFromFlag,
+    )
     const user = await this.whoAmI(url, token)
 
     await CredentialsService.writeToken(url, token, { email: user.email, username: user.username })
 
     if (returnUser) return {
       user,
-      token
+      token,
     }
 
     return token
@@ -81,6 +77,12 @@ export abstract class BaseService {
           Authorization: `Bearer ${config.token}`,
           'User-Agent': `shelve-cli/${getCliVersion()} (${process.platform}; node-${process.versions.node})`,
         },
+        onRequest({ request, options: reqOptions }) {
+          logHttpRequest(reqOptions.method || 'GET', request.toString())
+        },
+        onResponse({ request, response, options: reqOptions }) {
+          logHttpResponse(reqOptions.method || 'GET', request.toString(), response.status)
+        },
         onResponseError: ErrorService.handleApiError,
       })
     }
@@ -90,9 +92,27 @@ export abstract class BaseService {
   protected static async request<T>(endpoint: string, options?: FetchOptions<'json'>): Promise<T> {
     const api = await this.getApi()
 
-    return api<T>(endpoint, options)
+    try {
+      return await api<T>(endpoint, options)
+    } catch (error) {
+      throw toCliError(error)
+    }
   }
 
+}
+
+function logHttpRequest(method: string, url: string): void {
+  if (!isDebug()) return
+  debugLog(`HTTP ${method} ${sanitizeUrl(url)}`)
+}
+
+function logHttpResponse(method: string, url: string, status: number): void {
+  if (!isDebug()) return
+  debugLog(`HTTP ${method} ${sanitizeUrl(url)} → ${status}`)
+}
+
+function sanitizeUrl(url: string): string {
+  return url.replace(/Bearer\s+[^\s]+/gi, 'Bearer ***')
 }
 
 let _cliVersion = ''

--- a/packages/cli/src/services/env.ts
+++ b/packages/cli/src/services/env.ts
@@ -1,5 +1,4 @@
 import { parseEnvFile } from '@utils'
-import { log } from '@clack/prompts'
 import type {
   EnvVar,
   EnvVarExport,
@@ -8,6 +7,7 @@ import type {
   CreateVariablesInput,
   GetEnvVariables
 } from '@types'
+import { cliWarn } from '../utils/output'
 import { loadShelveConfig, askBoolean } from '../utils'
 import { FileService } from './file'
 import { BaseService } from './base'
@@ -104,7 +104,7 @@ export class EnvService extends BaseService {
     const { variables, project, slug, environment, confirmChanges, autoUppercase } = input
 
     if (variables.length === 0) {
-      log.warn('No variables found in the .env file')
+      cliWarn('No variables found in the .env file')
       return false
     }
 

--- a/packages/cli/src/services/environment.ts
+++ b/packages/cli/src/services/environment.ts
@@ -1,6 +1,7 @@
 import { isCancel } from '@clack/prompts'
 import type { Environment } from '@types'
-import { askSelect, capitalize, handleCancel } from '../utils'
+import { askSelect, capitalize, handleCancel, isNonInteractive } from '../utils'
+import { CliError } from './api-error'
 import { BaseService } from './base'
 
 export class EnvironmentService extends BaseService {
@@ -28,6 +29,14 @@ export class EnvironmentService extends BaseService {
       return await this.withLoading(`Fetch environment ${name}`, async () => {
         return await this.request<Environment>(`/teams/${ slug }/environments/${ name }`)
       })
+    }
+    if (isNonInteractive()) {
+      throw new CliError(
+        'Environment name is required.',
+        'MISSING_ENV',
+        undefined,
+        'Pass --env or set defaultEnv in shelve.json / SHELVE_DEFAULT_ENV.',
+      )
     }
     return await this.promptEnvironment(slug)
   }

--- a/packages/cli/src/services/project.ts
+++ b/packages/cli/src/services/project.ts
@@ -1,9 +1,9 @@
 import { type PackageJson, readPackageJSON } from 'pkg-types'
-import { log } from '@clack/prompts'
 import type { Project } from '@types'
+import { cliInfo } from '../utils/output'
+import { askBoolean, capitalize, handleCancel, isNonInteractive, shouldSkipConfirm } from '../utils'
 import { isDebug, debugLog } from '../constants'
-import { askBoolean, capitalize, handleCancel } from '../utils'
-import { isRecoverableHttpError } from './api-error'
+import { CliError, isRecoverableHttpError, toCliError } from './api-error'
 import { BaseService } from './base'
 
 export class ProjectService extends BaseService {
@@ -28,9 +28,19 @@ export class ProjectService extends BaseService {
 
       if (isRecoverableHttpError(error, [400])) {
         if (autoCreate) {
-          if (!name || !slug)
+          if (!name || !slug) {
             return handleCancel(`Project '${name}' does not exist, and could not be auto-created without a name and slug`)
+          }
           return this.createProject(name, slug, autoCreate)
+        }
+
+        if (isNonInteractive() && !shouldSkipConfirm()) {
+          throw new CliError(
+            `Project '${name}' does not exist.`,
+            'PROJECT_NOT_FOUND',
+            400,
+            'Enable autoCreateProject in shelve.json or pass --yes after creating the project manually.',
+          )
         }
 
         await askBoolean(`Project '${name}' does not exist. Would you like to create it?`)
@@ -38,7 +48,7 @@ export class ProjectService extends BaseService {
         return this.createProject(name, slug, autoCreate)
       }
 
-      process.exit(1)
+      throw toCliError(error)
     }
   }
 
@@ -50,7 +60,7 @@ export class ProjectService extends BaseService {
   }
 
   static async createProject(name: string, slug: string, autoCreate?: boolean): Promise<Project> {
-    if (autoCreate) log.info(`Auto-creating project '${name}'`)
+    if (autoCreate) cliInfo(`Auto-creating project '${name}'`)
     const pkg = await readPackageJSON()
     const input = {
       name: capitalize(name),

--- a/packages/cli/src/utils/cli-context.ts
+++ b/packages/cli/src/utils/cli-context.ts
@@ -86,6 +86,7 @@ export function isNonInteractiveExplicit(): boolean {
 
 export function getCommandFromArgv(argv: string[] = process.argv): string | undefined {
   for (const arg of argv.slice(2)) {
+    if (arg === '--') break
     if (GLOBAL_FLAG_NAMES.has(arg)) continue
     if (arg.startsWith('-')) continue
     return arg
@@ -94,5 +95,17 @@ export function getCommandFromArgv(argv: string[] = process.argv): string | unde
 }
 
 export function stripGlobalFlags(argv: string[]): string[] {
-  return argv.filter(arg => !GLOBAL_FLAG_NAMES.has(arg))
+  const result: string[] = []
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+    if (arg === '--') {
+      result.push(...argv.slice(i))
+      break
+    }
+    if (!GLOBAL_FLAG_NAMES.has(arg)) {
+      result.push(arg)
+    }
+  }
+  return result
 }

--- a/packages/cli/src/utils/cli-context.ts
+++ b/packages/cli/src/utils/cli-context.ts
@@ -1,0 +1,98 @@
+import { agent as detectedAgent } from 'std-env'
+
+let jsonMode = false
+let quietMode = false
+let yesMode = false
+let nonInteractiveFlag = false
+
+const GLOBAL_FLAG_NAMES = new Set([
+  '--json',
+  '--quiet',
+  '-q',
+  '--yes',
+  '-y',
+  '--non-interactive',
+  '--debug',
+])
+
+export const GLOBAL_CLI_ARGS = {
+  debug: {
+    type: 'boolean' as const,
+    description: 'Enable verbose debug logging (or set SHELVE_DEBUG=1)',
+    default: false,
+  },
+  json: {
+    type: 'boolean' as const,
+    description: 'Output machine-readable JSON on stdout; errors on stderr as JSON',
+    default: false,
+  },
+  quiet: {
+    type: 'boolean' as const,
+    alias: 'q',
+    description: 'Suppress intro/outro/spinners; minimal text output',
+    default: false,
+  },
+  yes: {
+    type: 'boolean' as const,
+    alias: 'y',
+    description: 'Skip confirmation prompts',
+    default: false,
+  },
+  'non-interactive': {
+    type: 'boolean' as const,
+    description: 'Fail instead of prompting when required input is missing',
+    default: false,
+  },
+}
+
+function hasFlag(argv: string[], ...flags: string[]): boolean {
+  return flags.some(flag => argv.includes(flag))
+}
+
+export function initCliContextFromArgv(argv: string[] = process.argv): void {
+  jsonMode = hasFlag(argv, '--json')
+  quietMode = hasFlag(argv, '--quiet', '-q')
+  yesMode = hasFlag(argv, '--yes', '-y')
+  nonInteractiveFlag = hasFlag(argv, '--non-interactive')
+
+  if (process.env.CI === 'true' || process.env.CI === '1') {
+    nonInteractiveFlag = true
+  }
+}
+
+export function isJson(): boolean {
+  return jsonMode
+}
+
+export function isQuiet(): boolean {
+  return quietMode
+}
+
+export function shouldSkipConfirm(): boolean {
+  return yesMode
+}
+
+export function isAgentShell(): boolean {
+  return Boolean(detectedAgent || process.env.AI_AGENT)
+}
+
+export function isNonInteractive(): boolean {
+  return nonInteractiveFlag || isAgentShell()
+}
+
+export function isNonInteractiveExplicit(): boolean {
+  return nonInteractiveFlag
+}
+
+export function getCommandFromArgv(argv: string[] = process.argv): string | undefined {
+  for (const arg of argv.slice(2)) {
+    if (GLOBAL_FLAG_NAMES.has(arg)) continue
+    if (arg.startsWith('-')) continue
+    return arg
+  }
+  return undefined
+}
+
+export function stripGlobalFlags(argv: string[]): string[] {
+  return argv.filter(arg => !GLOBAL_FLAG_NAMES.has(arg))
+}

--- a/packages/cli/src/utils/cli-context.ts
+++ b/packages/cli/src/utils/cli-context.ts
@@ -49,11 +49,17 @@ function hasFlag(argv: string[], ...flags: string[]): boolean {
   return flags.some(flag => argv.includes(flag))
 }
 
+function argvBeforeDoubleDash(argv: string[]): string[] {
+  const index = argv.indexOf('--')
+  return index >= 0 ? argv.slice(0, index) : argv
+}
+
 export function initCliContextFromArgv(argv: string[] = process.argv): void {
-  jsonMode = hasFlag(argv, '--json')
-  quietMode = hasFlag(argv, '--quiet', '-q')
-  yesMode = hasFlag(argv, '--yes', '-y')
-  nonInteractiveFlag = hasFlag(argv, '--non-interactive')
+  const cliArgv = argvBeforeDoubleDash(argv)
+  jsonMode = hasFlag(cliArgv, '--json')
+  quietMode = hasFlag(cliArgv, '--quiet', '-q')
+  yesMode = hasFlag(cliArgv, '--yes', '-y')
+  nonInteractiveFlag = hasFlag(cliArgv, '--non-interactive')
 
   if (process.env.CI === 'true' || process.env.CI === '1') {
     nonInteractiveFlag = true

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -18,7 +18,6 @@
  */
 
 import { join } from 'path'
-import { intro, outro } from '@clack/prompts'
 import { setupDotenv } from 'c12'
 import { findWorkspaceDir, readPackageJSON } from 'pkg-types'
 import defu from 'defu'
@@ -27,8 +26,8 @@ import { DEFAULT_URL, SHELVE_JSON_SCHEMA } from '@types'
 import { CredentialsService, FileService, PkgService, ProjectService } from '../services'
 import { DEFAULT_ENV_FILENAME } from '../constants'
 import { BaseService } from '../services/base'
-import { askSelect, askText } from './prompt'
-import { handleCancel } from '.'
+import { CliError } from '../services/api-error'
+import { askSelect, askText, cliIntro, cliOutro, handleCancel, isNonInteractive } from '.'
 
 export const CONFIG_FILENAMES = [
   'shelve.json',
@@ -81,25 +80,36 @@ function createConfigFile(config: string, preferredFilename: ConfigFileName = CO
  * 4. Create shelve.json file with the configuration
  */
 export async function createShelveConfig(input: CreateShelveConfigInput = {}): Promise<ShelveConfig> {
-  intro(input.projectName ? `Create configuration for ${ input.projectName }` : 'No configuration file found, create a new one')
+  if (isNonInteractive() && !input.slug && !input.projectName) {
+    throw new CliError(
+      'No shelve.json found in this directory.',
+      'CONFIG_MISSING',
+      undefined,
+      'Create shelve.json or set SHELVE_TEAM_SLUG, SHELVE_PROJECT, and SHELVE_TOKEN.',
+    )
+  }
+
+  cliIntro(input.projectName ? `Create configuration for ${ input.projectName }` : 'No configuration file found, create a new one')
 
   const defaultConfig = await getDefaultConfig()
 
-  const slug = input.slug || defaultConfig.slug || await askText('Enter the team slug:', 'my-team-slug')
+  const slug = input.slug || defaultConfig.slug || await askText(
+    'Enter the team slug:',
+    'my-team-slug',
+    undefined,
+    'Set SHELVE_TEAM_SLUG or pass --slug.',
+  )
   const projectName = input.projectName || defaultConfig.project || await selectProject(slug)
 
   if (!projectName) handleCancel('Error: no project selected')
 
-  const config = JSON.stringify({
+  createConfigFile(JSON.stringify({
     $schema: SHELVE_JSON_SCHEMA,
     project: projectName.toLowerCase(),
-    slug
-  }, null, 2)
+    slug,
+  }, null, 2))
 
-  createConfigFile(config)
-
-  outro('Configuration file created successfully')
-
+  cliOutro('Configuration file created successfully')
 
   return defu({ project: projectName, slug }, defaultConfig)
 }
@@ -231,8 +241,28 @@ export async function loadShelveConfig(check = false): Promise<ShelveConfig> {
  */
 async function validateConfig(config: ShelveConfig): Promise<void> {
   if (!config.token) await BaseService.getToken()
-  if (!config.slug) handleCancel('You need to provide your team slug')
-  if (!config.project) handleCancel('Please provide a project name')
+  if (!config.slug) {
+    if (isNonInteractive()) {
+      throw new CliError(
+        'Team slug is required.',
+        'MISSING_SLUG',
+        undefined,
+        'Set slug in shelve.json or SHELVE_TEAM_SLUG.',
+      )
+    }
+    handleCancel('You need to provide your team slug')
+  }
+  if (!config.project) {
+    if (isNonInteractive()) {
+      throw new CliError(
+        'Project name is required.',
+        'MISSING_PROJECT',
+        undefined,
+        'Set project in shelve.json or SHELVE_PROJECT.',
+      )
+    }
+    handleCancel('Please provide a project name')
+  }
   if (config.url !== DEFAULT_URL && !/^(http|https):\/\/[^ "]+$/.test(config.url)) {
     handleCancel('Please provide a valid url')
   }

--- a/packages/cli/src/utils/error-codes.ts
+++ b/packages/cli/src/utils/error-codes.ts
@@ -1,0 +1,73 @@
+export const EXIT_CODES = {
+  0: 'Success',
+  1: 'CLI, API, or validation error',
+  129: 'Parent process gone or stdin EIO',
+  130: 'SIGINT (user interrupt, often normalized to 0 in run)',
+  143: 'SIGTERM',
+} as const
+
+export const CLI_ERROR_CODES: Record<string, { meaning: string, hint?: string }> = {
+  AGENT_BLOCKED: {
+    meaning: 'shelve pull refused in an AI agent shell without --yes',
+    hint: 'Prefer `shelve run -- <cmd>` or pass --yes to write secrets to disk.',
+  },
+  AUTH_REQUIRED: {
+    meaning: 'No API token available',
+    hint: 'Set SHELVE_TOKEN or run `shelve login`.',
+  },
+  CONFIG_MISSING: {
+    meaning: 'No shelve.json and required config not provided via env',
+    hint: 'Create shelve.json or set SHELVE_TEAM_SLUG and SHELVE_PROJECT.',
+  },
+  CONFIRMATION_REQUIRED: {
+    meaning: 'A confirmation prompt would be shown in interactive mode',
+    hint: 'Pass --yes or --non-interactive.',
+  },
+  FETCH_FAILED: {
+    meaning: 'Could not fetch secrets from Shelve',
+    hint: 'Check network, token scopes, and offline cache.',
+  },
+  FORBIDDEN: {
+    meaning: 'Token lacks permission for this action',
+  },
+  INVALID_INPUT: {
+    meaning: 'Invalid flag or argument value',
+  },
+  MISSING_ENV: {
+    meaning: 'Environment name is required',
+    hint: 'Pass --env or set defaultEnv / SHELVE_DEFAULT_ENV.',
+  },
+  MISSING_INPUT: {
+    meaning: 'Required value missing in non-interactive mode',
+  },
+  MISSING_PROJECT: {
+    meaning: 'Project name is required',
+    hint: 'Set project in shelve.json or SHELVE_PROJECT.',
+  },
+  MISSING_SLUG: {
+    meaning: 'Team slug is required',
+    hint: 'Set slug in shelve.json or SHELVE_TEAM_SLUG.',
+  },
+  NOT_FOUND: {
+    meaning: 'Resource not found on Shelve',
+  },
+  OPERATION_FAILED: {
+    meaning: 'Generic operation failure',
+  },
+  PROJECT_NOT_FOUND: {
+    meaning: 'Project does not exist and was not auto-created',
+  },
+  USER_CANCELLED: {
+    meaning: 'User aborted an interactive prompt',
+  },
+}
+
+export function formatErrorCodesHelp(): string {
+  const lines = ['Structured error codes (JSON stderr or `shelve doctor`):']
+  for (const [code, { meaning }] of Object.entries(CLI_ERROR_CODES)) {
+    lines.push(`  ${code} — ${meaning}`)
+  }
+  lines.push('')
+  lines.push('Exit codes: 0 ok · 1 error · 129 parent/EIO · 130 SIGINT · 143 SIGTERM · 128+n child signal (run)')
+  return lines.join('\n')
+}

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -36,25 +36,33 @@ async function fetchLatestCliVersion(): Promise<string> {
 }
 
 export async function isLatestVersion(): Promise<boolean> {
-  if (!isQuiet() && !isJson()) s.start('Checking for updates')
+  const showSpinner = !isQuiet() && !isJson()
+  if (showSpinner) s.start('Checking for updates')
 
-  const latestVersion = await fetchLatestCliVersion()
+  try {
+    const latestVersion = await fetchLatestCliVersion()
+    const isUpdated = semver.gte(version, latestVersion)
 
-  if (!isQuiet() && !isJson()) s.stop('Checking for updates')
-  const isUpdated = semver.gte(version, latestVersion)
+    if (!isUpdated && showSpinner)
+      note(`Shelve CLI ${version} is available (latest version is ${latestVersion})`, 'Update available')
 
-  if (!isUpdated && !isQuiet() && !isJson())
-    note(`Shelve CLI ${version} is available (latest version is ${latestVersion})`, 'Update available')
-
-  return isUpdated
+    return isUpdated
+  } finally {
+    if (showSpinner) s.stop('Checking for updates')
+  }
 }
 
 export async function installLatest(): Promise<string> {
+  const showSpinner = !isQuiet() && !isJson()
   const latestVersion = await fetchLatestCliVersion()
-  if (!isQuiet() && !isJson()) s.start('Updating Shelve CLI')
-  await addDependency('@shelve/cli@latest', {
-    silent: true,
-  })
-  if (!isQuiet() && !isJson()) s.stop('Updating Shelve CLI')
-  return latestVersion
+  if (showSpinner) s.start('Updating Shelve CLI')
+
+  try {
+    await addDependency('@shelve/cli@latest', {
+      silent: true,
+    })
+    return latestVersion
+  } finally {
+    if (showSpinner) s.stop('Updating Shelve CLI')
+  }
 }

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,8 +1,10 @@
-import { spinner, note, cancel } from '@clack/prompts'
+import { spinner, note } from '@clack/prompts'
 import { addDependency } from 'nypm'
 import semver from 'semver'
 import npmFetch from 'npm-registry-fetch'
 import { version } from '../../package.json'
+import { isJson, isQuiet } from './cli-context'
+import { cliCancel } from './output'
 
 export * from './templates'
 export * from './prompt'
@@ -10,12 +12,13 @@ export * from './config'
 export * from './duration'
 export * from './secret-refs'
 export * from './ignore-files'
+export * from './cli-context'
+export * from './output'
 
 const s = spinner()
 
 export function handleCancel(message: string): never {
-  cancel(message)
-  process.exit(1)
+  return cliCancel(message)
 }
 
 export function capitalize(str: string): string {
@@ -23,7 +26,7 @@ export function capitalize(str: string): string {
 }
 
 export async function isLatestVersion(): Promise<boolean> {
-  s.start('Checking for updates')
+  if (!isQuiet() && !isJson()) s.start('Checking for updates')
 
   const packageInfo = await npmFetch.json('/@shelve/cli') as {
     'dist-tags': {
@@ -31,21 +34,21 @@ export async function isLatestVersion(): Promise<boolean> {
     }
   }
 
-  s.stop('Checking for updates')
+  if (!isQuiet() && !isJson()) s.stop('Checking for updates')
 
   const latestVersion = packageInfo['dist-tags'].latest
   const isUpdated = semver.gte(version, latestVersion)
 
-  if (!isUpdated)
+  if (!isUpdated && !isQuiet() && !isJson())
     note(`Shelve CLI ${version} is available (latest version is ${latestVersion})`, 'Update available')
 
   return isUpdated
 }
 
 export async function installLatest(): Promise<void> {
-  s.start('Updating Shelve CLI')
+  if (!isQuiet() && !isJson()) s.start('Updating Shelve CLI')
   await addDependency('@shelve/cli@latest', {
     silent: true,
   })
-  s.stop('Updating Shelve CLI')
+  if (!isQuiet() && !isJson()) s.stop('Updating Shelve CLI')
 }

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -26,18 +26,21 @@ export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-export async function isLatestVersion(): Promise<boolean> {
-  if (!isQuiet() && !isJson()) s.start('Checking for updates')
-
+async function fetchLatestCliVersion(): Promise<string> {
   const packageInfo = await npmFetch.json('/@shelve/cli') as {
     'dist-tags': {
       latest: string
     }
   }
+  return packageInfo['dist-tags'].latest
+}
+
+export async function isLatestVersion(): Promise<boolean> {
+  if (!isQuiet() && !isJson()) s.start('Checking for updates')
+
+  const latestVersion = await fetchLatestCliVersion()
 
   if (!isQuiet() && !isJson()) s.stop('Checking for updates')
-
-  const latestVersion = packageInfo['dist-tags'].latest
   const isUpdated = semver.gte(version, latestVersion)
 
   if (!isUpdated && !isQuiet() && !isJson())
@@ -46,10 +49,12 @@ export async function isLatestVersion(): Promise<boolean> {
   return isUpdated
 }
 
-export async function installLatest(): Promise<void> {
+export async function installLatest(): Promise<string> {
+  const latestVersion = await fetchLatestCliVersion()
   if (!isQuiet() && !isJson()) s.start('Updating Shelve CLI')
   await addDependency('@shelve/cli@latest', {
     silent: true,
   })
   if (!isQuiet() && !isJson()) s.stop('Updating Shelve CLI')
+  return latestVersion
 }

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -14,6 +14,7 @@ export * from './secret-refs'
 export * from './ignore-files'
 export * from './cli-context'
 export * from './output'
+export * from './error-codes'
 
 const s = spinner()
 

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -44,10 +44,10 @@ export function writeJsonError(error: CliErrorInput): void {
 }
 
 export function cliError(input: CliErrorInput): never {
-  const message = input.hint ? `${input.message} ${input.hint}` : input.message
   if (isJson()) {
-    writeJsonError({ ...input, message })
+    writeJsonError(input)
   } else {
+    const message = input.hint ? `${input.message} ${input.hint}` : input.message
     console.error(message)
   }
   process.exit(1)
@@ -137,7 +137,7 @@ export async function withSpinner<T>(
       s.stop(message)
       throw error
     }
-    s.cancel(formatCliError(error, message))
+    s.cancel()
     handleThrownError(error, message)
   }
 }

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -63,6 +63,11 @@ export function cliOutro(message: string): void {
   outro(message)
 }
 
+export function cliJsonEvent(event: string, data?: Record<string, unknown>): void {
+  if (!isJson()) return
+  console.error(JSON.stringify({ ok: true, event, ...data }))
+}
+
 export function cliSuccess(data?: unknown, message?: string, command?: string): void {
   if (isJson()) {
     writeJsonSuccess(data, command || getCommandFromArgv())

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -1,0 +1,153 @@
+import { cancel, intro, log, outro, spinner } from '@clack/prompts'
+import type { ShelveConfig } from '@types'
+import { CliError, formatCliError } from '../services/api-error'
+import {
+  getCommandFromArgv,
+  isJson,
+  isNonInteractive,
+  isQuiet,
+  shouldSkipConfirm,
+} from './cli-context'
+
+export type CliErrorInput = {
+  code: string
+  message: string
+  status?: number
+  hint?: string
+}
+
+export function redactConfig(config: ShelveConfig): Omit<ShelveConfig, 'token'> & { token?: string } {
+  const { token, ...rest } = config
+  return {
+    ...rest,
+    ...(token ? { token: '***' } : {}),
+  }
+}
+
+export function writeJsonSuccess(data?: unknown, command?: string): void {
+  const payload: Record<string, unknown> = { ok: true }
+  if (command) payload.command = command
+  if (data !== undefined) payload.data = data
+  console.log(JSON.stringify(payload))
+}
+
+export function writeJsonError(error: CliErrorInput): void {
+  console.error(JSON.stringify({
+    ok: false,
+    error: {
+      code: error.code,
+      message: error.message,
+      ...(error.status !== undefined ? { status: error.status } : {}),
+      ...(error.hint ? { hint: error.hint } : {}),
+    },
+  }))
+}
+
+export function cliError(input: CliErrorInput): never {
+  const message = input.hint ? `${input.message} ${input.hint}` : input.message
+  if (isJson()) {
+    writeJsonError({ ...input, message })
+  } else {
+    console.error(message)
+  }
+  process.exit(1)
+}
+
+export function cliIntro(message: string): void {
+  if (isJson() || isQuiet()) return
+  intro(message)
+}
+
+export function cliOutro(message: string): void {
+  if (isJson() || isQuiet()) return
+  outro(message)
+}
+
+export function cliSuccess(data?: unknown, message?: string, command?: string): void {
+  if (isJson()) {
+    writeJsonSuccess(data, command || getCommandFromArgv())
+    return
+  }
+  if (message && !isQuiet()) outro(message)
+}
+
+export function cliInfo(message: string): void {
+  if (isQuiet() || isJson()) return
+  log.info(message)
+}
+
+export function cliSuccessLog(message: string): void {
+  if (isQuiet() || isJson()) return
+  log.success(message)
+}
+
+export function cliWarn(message: string): void {
+  if (isQuiet()) return
+  if (isJson()) {
+    console.error(JSON.stringify({ ok: true, warning: message }))
+    return
+  }
+  log.warn(message)
+}
+
+export function cliCancel(message: string): never {
+  if (isJson()) {
+    writeJsonError({ code: 'USER_CANCELLED', message })
+  } else {
+    cancel(message)
+  }
+  process.exit(1)
+}
+
+export function requireNonInteractive(message: string, hint?: string): void {
+  if (isNonInteractive()) {
+    throw new CliError(message, 'MISSING_INPUT', undefined, hint)
+  }
+}
+
+export { shouldSkipConfirm }
+
+export async function withSpinner<T>(
+  message: string,
+  callback: () => Promise<T>,
+  options?: { recoverable?: (error: unknown) => boolean },
+): Promise<T> {
+  if (isQuiet() || isJson()) {
+    try {
+      return await callback()
+    } catch (error) {
+      if (options?.recoverable?.(error)) throw error
+      handleThrownError(error, message)
+    }
+  }
+
+  const s = spinner()
+  try {
+    s.start(message)
+    const result = await callback()
+    s.stop(message)
+    return result
+  } catch (error) {
+    if (options?.recoverable?.(error)) {
+      s.stop(message)
+      throw error
+    }
+    s.cancel(formatCliError(error, message))
+    handleThrownError(error, message)
+  }
+}
+
+function handleThrownError(error: unknown, context?: string): never {
+  if (error instanceof CliError) {
+    cliError({
+      code: error.code,
+      message: error.message,
+      status: error.status,
+      hint: error.hint,
+    })
+  }
+  cliError({
+    code: 'OPERATION_FAILED',
+    message: formatCliError(error, context),
+  })
+}

--- a/packages/cli/src/utils/prompt.ts
+++ b/packages/cli/src/utils/prompt.ts
@@ -1,25 +1,53 @@
 import { confirm, isCancel, select, text, password } from '@clack/prompts'
-import { handleCancel } from '.'
+import { CliError } from '../services/api-error'
+import { isNonInteractive, shouldSkipConfirm } from './cli-context'
+import { cliCancel } from './output'
 
 export async function askBoolean(message: string): Promise<symbol | boolean> {
-  const response = await confirm({
-    message,
-  })
-  if (!response) return handleCancel('Operation cancelled.')
+  if (shouldSkipConfirm()) return true
+
+  if (isNonInteractive()) {
+    throw new CliError(
+      message,
+      'CONFIRMATION_REQUIRED',
+      undefined,
+      'Pass --yes to skip confirmation prompts.',
+    )
+  }
+
+  const response = await confirm({ message })
+  if (!response) return cliCancel('Operation cancelled.')
   return response
 }
 
-export async function askSelect<T>(message: string, options: { value: T, label: string }[]): Promise<T> {
+export async function askSelect<T>(
+  message: string,
+  options: { value: T, label: string }[],
+  hint = 'Pass the required flag or set the matching SHELVE_* environment variable.',
+): Promise<T> {
+  if (isNonInteractive()) {
+    throw new CliError(message, 'MISSING_INPUT', undefined, hint)
+  }
+
   const response = await select({
     message,
     // @ts-expect-error - TODO: fix this
     options,
   })
-  if (isCancel(response)) handleCancel('Operation cancelled.')
+  if (isCancel(response)) cliCancel('Operation cancelled.')
   return response
 }
 
-export async function askText(message: string, placeholder?: string, initialValue?: string): Promise<string> {
+export async function askText(
+  message: string,
+  placeholder?: string,
+  initialValue?: string,
+  hint = 'Pass the required flag or set the matching SHELVE_* environment variable.',
+): Promise<string> {
+  if (isNonInteractive()) {
+    throw new CliError(message, 'MISSING_INPUT', undefined, hint)
+  }
+
   const response = await text({
     message,
     placeholder,
@@ -28,17 +56,30 @@ export async function askText(message: string, placeholder?: string, initialValu
       if (!value?.length) return 'Value is required!'
     },
   })
-  if (isCancel(response)) handleCancel('Operation cancelled.')
+  if (isCancel(response)) cliCancel('Operation cancelled.')
   return response
 }
 
-export async function askPassword(message: string): Promise<string> {
+export async function askPassword(message: string, tokenFromFlag?: string): Promise<string> {
+  const envToken = process.env.SHELVE_TOKEN
+  if (tokenFromFlag) return tokenFromFlag
+  if (envToken) return envToken
+
+  if (isNonInteractive()) {
+    throw new CliError(
+      'Authentication token is required.',
+      'AUTH_REQUIRED',
+      undefined,
+      'Set SHELVE_TOKEN or pass --token to shelve login.',
+    )
+  }
+
   const response = await password({
     message,
     validate(value) {
       if (!value?.length) return 'Value is required!'
     },
   })
-  if (isCancel(response)) handleCancel('Operation cancelled.')
+  if (isCancel(response)) cliCancel('Operation cancelled.')
   return response
 }

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -15,39 +15,42 @@ export async function getEslintConfig(): Promise<string> {
   const path = 'eslint.config.js'
   cliIntro('Generate ESLint config')
 
-  if (!isQuiet() && !isJson()) {
-    s.start('Fetching ESLint config')
-  }
+  const showFetchSpinner = !isQuiet() && !isJson()
+  if (showFetchSpinner) s.start('Fetching ESLint config')
 
+  let text: string
   try {
     const response = await fetch(templates.eslint)
     if (!response.ok) {
       throw new Error(`Failed to fetch ESLint config: ${response.status} ${response.statusText}`)
     }
-    const text = await response.text()
-
-    FileService.write(path, text)
-
-    if (!isQuiet() && !isJson()) {
-      s.stop('Fetching ESLint config')
-      note('ESLint config has been generated', 'ESLint config')
-    }
-
-    const shouldInstall = isNonInteractive()
-      ? false
-      : shouldSkipConfirm()
-        ? true
-        : await askBoolean('Do you want to install ESLint and @hrcd/eslint-config?')
-
-    if (shouldInstall) {
-      if (!isQuiet() && !isJson()) s.start('Installing eslint and @hrcd/eslint-config')
-      await addDevDependency('eslint', { silent: true })
-      await addDevDependency('@hrcd/eslint-config', { silent: true })
-      if (!isQuiet() && !isJson()) s.stop('Installing ESLint and @hrcd/eslint-config')
-    }
-
-    return path
-  } catch {
-    cliCancel('Failed to fetch ESLint config')
+    text = await response.text()
+  } catch (err) {
+    if (showFetchSpinner) s.stop('Fetching ESLint config')
+    const message = err instanceof Error ? err.message : 'Failed to fetch ESLint config'
+    cliCancel(message)
+  } finally {
+    if (showFetchSpinner) s.stop('Fetching ESLint config')
   }
+
+  FileService.write(path, text)
+
+  if (!isQuiet() && !isJson()) {
+    note('ESLint config has been generated', 'ESLint config')
+  }
+
+  const shouldInstall = isNonInteractive()
+    ? false
+    : shouldSkipConfirm()
+      ? true
+      : await askBoolean('Do you want to install ESLint and @hrcd/eslint-config?')
+
+  if (shouldInstall) {
+    if (!isQuiet() && !isJson()) s.start('Installing eslint and @hrcd/eslint-config')
+    await addDevDependency('eslint', { silent: true })
+    await addDevDependency('@hrcd/eslint-config', { silent: true })
+    if (!isQuiet() && !isJson()) s.stop('Installing ESLint and @hrcd/eslint-config')
+  }
+
+  return path
 }

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -1,43 +1,50 @@
 import { addDevDependency } from 'nypm'
-import { spinner, note, intro } from '@clack/prompts'
+import { note, spinner } from '@clack/prompts'
 import { FileService } from '../services'
 import { askBoolean } from './prompt'
-import { handleCancel } from '.'
+import { cliCancel, cliIntro } from './output'
+import { isJson, isNonInteractive, isQuiet, shouldSkipConfirm } from './cli-context'
 
 const s = spinner()
 
 const templates = {
-  eslint: 'https://raw.githubusercontent.com/HugoRCD/templates/main/eslint.config.js'
+  eslint: 'https://raw.githubusercontent.com/HugoRCD/templates/main/eslint.config.js',
 }
 
-export async function getEslintConfig(): Promise<void> {
-  intro('Generate ESLint config')
+export async function getEslintConfig(): Promise<string> {
+  const path = 'eslint.config.js'
+  cliIntro('Generate ESLint config')
 
-  s.start('Fetching ESLint config')
+  if (!isQuiet() && !isJson()) {
+    s.start('Fetching ESLint config')
+  }
 
   try {
     const response = await fetch(templates.eslint)
     const text = await response.text()
 
-    FileService.write('eslint.config.js', text)
+    FileService.write(path, text)
 
-    s.stop('Fetching ESLint config')
-
-    note('ESLint config has been generated', 'ESLint config')
-
-    const install = await askBoolean('Do you want to install ESLint and @hrcd/eslint-config?')
-
-    if (install) {
-      s.start('Installing eslint and @hrcd/eslint-config')
-      await addDevDependency('eslint', {
-        silent: true
-      })
-      await addDevDependency('@hrcd/eslint-config', {
-        silent: true
-      })
-      s.stop('Installing ESLint and @hrcd/eslint-config')
+    if (!isQuiet() && !isJson()) {
+      s.stop('Fetching ESLint config')
+      note('ESLint config has been generated', 'ESLint config')
     }
-  } catch (error) {
-    handleCancel('Failed to fetch ESLint config')
+
+    const shouldInstall = shouldSkipConfirm()
+      ? false
+      : isNonInteractive()
+        ? false
+        : await askBoolean('Do you want to install ESLint and @hrcd/eslint-config?')
+
+    if (shouldInstall) {
+      if (!isQuiet() && !isJson()) s.start('Installing eslint and @hrcd/eslint-config')
+      await addDevDependency('eslint', { silent: true })
+      await addDevDependency('@hrcd/eslint-config', { silent: true })
+      if (!isQuiet() && !isJson()) s.stop('Installing ESLint and @hrcd/eslint-config')
+    }
+
+    return path
+  } catch {
+    cliCancel('Failed to fetch ESLint config')
   }
 }

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -21,6 +21,9 @@ export async function getEslintConfig(): Promise<string> {
 
   try {
     const response = await fetch(templates.eslint)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ESLint config: ${response.status} ${response.statusText}`)
+    }
     const text = await response.text()
 
     FileService.write(path, text)
@@ -30,10 +33,10 @@ export async function getEslintConfig(): Promise<string> {
       note('ESLint config has been generated', 'ESLint config')
     }
 
-    const shouldInstall = shouldSkipConfirm()
+    const shouldInstall = isNonInteractive()
       ? false
-      : isNonInteractive()
-        ? false
+      : shouldSkipConfirm()
+        ? true
         : await askBoolean('Do you want to install ESLint and @hrcd/eslint-config?')
 
     if (shouldInstall) {

--- a/packages/cli/test/cli-context.test.ts
+++ b/packages/cli/test/cli-context.test.ts
@@ -13,8 +13,10 @@ const ORIGINAL_AI_AGENT = process.env.AI_AGENT
 const ORIGINAL_CI = process.env.CI
 
 afterEach(() => {
-  process.env.AI_AGENT = ORIGINAL_AI_AGENT
-  process.env.CI = ORIGINAL_CI
+  if (ORIGINAL_AI_AGENT === undefined) delete process.env.AI_AGENT
+  else process.env.AI_AGENT = ORIGINAL_AI_AGENT
+  if (ORIGINAL_CI === undefined) delete process.env.CI
+  else process.env.CI = ORIGINAL_CI
   initCliContextFromArgv(['node', 'shelve'])
 })
 
@@ -50,5 +52,15 @@ describe('getCommandFromArgv', () => {
 describe('stripGlobalFlags', () => {
   it('removes known global flags', () => {
     expect(stripGlobalFlags(['shelve', '--json', 'config', '--quiet'])).toEqual(['shelve', 'config'])
+  })
+
+  it('preserves args after --', () => {
+    expect(stripGlobalFlags(['shelve', '--json', 'run', '--', '--watch', 'dev'])).toEqual(['shelve', 'run', '--', '--watch', 'dev'])
+  })
+})
+
+describe('getCommandFromArgv with -- separator', () => {
+  it('ignores args after --', () => {
+    expect(getCommandFromArgv(['node', 'shelve', 'run', '--', '--json', 'config'])).toBe('run')
   })
 })

--- a/packages/cli/test/cli-context.test.ts
+++ b/packages/cli/test/cli-context.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getCommandFromArgv,
+  initCliContextFromArgv,
+  isJson,
+  isNonInteractive,
+  isQuiet,
+  shouldSkipConfirm,
+  stripGlobalFlags,
+} from '../src/utils/cli-context'
+
+const ORIGINAL_AI_AGENT = process.env.AI_AGENT
+const ORIGINAL_CI = process.env.CI
+
+afterEach(() => {
+  process.env.AI_AGENT = ORIGINAL_AI_AGENT
+  process.env.CI = ORIGINAL_CI
+  initCliContextFromArgv(['node', 'shelve'])
+})
+
+describe('initCliContextFromArgv', () => {
+  it('parses global flags anywhere in argv', () => {
+    initCliContextFromArgv(['node', 'shelve', 'run', '--json', '--quiet', '--yes', '--non-interactive', '--', 'pnpm', 'dev'])
+    expect(isJson()).toBe(true)
+    expect(isQuiet()).toBe(true)
+    expect(shouldSkipConfirm()).toBe(true)
+    expect(isNonInteractive()).toBe(true)
+  })
+
+  it('treats CI as non-interactive', () => {
+    process.env.CI = 'true'
+    initCliContextFromArgv(['node', 'shelve', 'config'])
+    expect(isNonInteractive()).toBe(true)
+  })
+
+  it('treats AI_AGENT as non-interactive', () => {
+    process.env.AI_AGENT = 'cursor'
+    initCliContextFromArgv(['node', 'shelve', 'config'])
+    expect(isNonInteractive()).toBe(true)
+  })
+})
+
+describe('getCommandFromArgv', () => {
+  it('returns the first non-flag subcommand', () => {
+    expect(getCommandFromArgv(['node', 'shelve', '--json', 'config'])).toBe('config')
+    expect(getCommandFromArgv(['node', 'shelve', 'run', '--', 'pnpm', 'dev'])).toBe('run')
+  })
+})
+
+describe('stripGlobalFlags', () => {
+  it('removes known global flags', () => {
+    expect(stripGlobalFlags(['shelve', '--json', 'config', '--quiet'])).toEqual(['shelve', 'config'])
+  })
+})

--- a/packages/cli/test/cli-context.test.ts
+++ b/packages/cli/test/cli-context.test.ts
@@ -64,3 +64,11 @@ describe('getCommandFromArgv with -- separator', () => {
     expect(getCommandFromArgv(['node', 'shelve', 'run', '--', '--json', 'config'])).toBe('run')
   })
 })
+
+describe('initCliContextFromArgv with -- separator', () => {
+  it('ignores global flags after -- when initializing context', () => {
+    initCliContextFromArgv(['node', 'shelve', 'run', '--', '--json', '--yes'])
+    expect(isJson()).toBe(false)
+    expect(shouldSkipConfirm()).toBe(false)
+  })
+})

--- a/packages/cli/test/error-codes.test.ts
+++ b/packages/cli/test/error-codes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { CLI_ERROR_CODES, formatErrorCodesHelp } from '../src/utils/error-codes'
+
+describe('error-codes', () => {
+  it('documents AGENT_BLOCKED and AUTH_REQUIRED', () => {
+    expect(CLI_ERROR_CODES.AGENT_BLOCKED?.meaning).toContain('pull')
+    expect(CLI_ERROR_CODES.AUTH_REQUIRED?.hint).toContain('SHELVE_TOKEN')
+  })
+
+  it('formatErrorCodesHelp includes exit codes', () => {
+    const help = formatErrorCodesHelp()
+    expect(help).toContain('AGENT_BLOCKED')
+    expect(help).toContain('0 ok')
+  })
+})

--- a/packages/cli/test/non-interactive.test.ts
+++ b/packages/cli/test/non-interactive.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { CliError } from '../src/services/api-error'
+import { initCliContextFromArgv } from '../src/utils/cli-context'
+import { askText } from '../src/utils/prompt'
+
+afterEach(() => {
+  initCliContextFromArgv(['node', 'shelve'])
+})
+
+describe('non-interactive prompts', () => {
+  it('throws CliError instead of prompting', async () => {
+    initCliContextFromArgv(['node', 'shelve', '--non-interactive', 'create'])
+    await expect(askText('Enter project name')).rejects.toBeInstanceOf(CliError)
+    await expect(askText('Enter project name')).rejects.toMatchObject({
+      code: 'MISSING_INPUT',
+    })
+  })
+})

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ShelveConfig } from '@types'
+import { initCliContextFromArgv } from '../src/utils/cli-context'
+import { redactConfig, writeJsonError, writeJsonSuccess } from '../src/utils/output'
+
+afterEach(() => {
+  initCliContextFromArgv(['node', 'shelve'])
+})
+
+describe('redactConfig', () => {
+  it('redacts tokens from config output', () => {
+    const config = {
+      project: 'demo',
+      slug: 'team',
+      token: 'secret-token',
+      url: 'https://app.shelve.cloud',
+      confirmChanges: false,
+      envFileName: '.env',
+      autoUppercase: true,
+      autoCreateProject: true,
+      workspaceDir: '/tmp',
+      isMonoRepo: false,
+      isRoot: true,
+    } satisfies ShelveConfig
+
+    expect(redactConfig(config).token).toBe('***')
+  })
+
+  it('omits token when absent', () => {
+    const config = {
+      project: 'demo',
+      slug: 'team',
+      token: '',
+      url: 'https://app.shelve.cloud',
+      confirmChanges: false,
+      envFileName: '.env',
+      autoUppercase: true,
+      autoCreateProject: true,
+      workspaceDir: '/tmp',
+      isMonoRepo: false,
+      isRoot: true,
+    } satisfies ShelveConfig
+
+    expect(redactConfig(config).token).toBeUndefined()
+  })
+})
+
+describe('JSON writers', () => {
+  it('writes success payloads to stdout', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    writeJsonSuccess({ ok: true }, 'config')
+    expect(log).toHaveBeenCalledWith(JSON.stringify({ ok: true, command: 'config', data: { ok: true } }))
+    log.mockRestore()
+  })
+
+  it('writes error payloads to stderr', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    writeJsonError({ code: 'MISSING_ENV', message: 'Environment required', hint: 'Pass --env.' })
+    expect(error).toHaveBeenCalledWith(JSON.stringify({
+      ok: false,
+      error: {
+        code: 'MISSING_ENV',
+        message: 'Environment required',
+        hint: 'Pass --env.',
+      },
+    }))
+    error.mockRestore()
+  })
+})

--- a/playground/run/README.md
+++ b/playground/run/README.md
@@ -30,6 +30,8 @@ pnpm play:fail         # = shelve run fail   (verifies exit-code propagation)
 pnpm play:watch        # = shelve run dev --watch  (poll-based reload via SIGHUP)
 
 pnpm play -- --debug   # forward flags to the CLI
+pnpm play -- --json config   # machine-readable config (token redacted)
+pnpm play -- --non-interactive --yes pull --env development   # agent-style pull smoke
 pnpm play:server       # only the fake API (handy when iterating on the server itself)
 ```
 


### PR DESCRIPTION
## Summary

- Add global CLI flags (`--json`, `--quiet`, `--yes`, `--non-interactive`, `--debug`) with auto-detection in CI/agent shells, structured JSON errors on stderr, and non-interactive guards across all commands.
- Extend commands with machine-readable output, `login --token`, `generate --type`, `push --yes`, and fix silent fetch failures in `shelve run`.
- Refresh shelve.cloud CLI documentation (v5 accuracy) and publish a Docus agent skill at `/.well-known/skills/` (`npx skills add https://shelve.cloud`).

## Test plan

- [x] `pnpm --filter @shelve/cli test` (61 tests)
- [ ] `pnpm play -- --json config` — JSON output with redacted token
- [ ] `pnpm play` — `shelve run` end-to-end against fake API
- [ ] After LP deploy: `curl https://shelve.cloud/.well-known/skills/index.json` lists `shelve` skill
- [ ] Agent shell: `shelve pull` without `--yes` returns `AGENT_BLOCKED`
- [ ] CI-style: `SHELVE_TOKEN=… shelve --non-interactive run -- echo ok`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global CLI flags for automation: --json, --quiet, --yes, --non-interactive
  * New doctor command for preflight checks and CI validation
  * GitHub composite action for non-interactive shelve run usage
  * Published agent skill artifacts and skills catalog endpoint

* **Behavior Changes**
  * Structured/machine-readable JSON output and errors (token redaction)
  * Agent/CI guards: non-interactive enforcement and pull blocked unless confirmed

* **Documentation**
  * Expanded agents & automation, troubleshooting, command reference, and examples

* **Tests**
  * Added tests for CLI context, error codes, and non-interactive flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/shelve/pull/751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->