### PR TITLE
feat(app): overhaul audit log UX

### DIFF
--- a/.changeset/audit-log-ux-overhaul.md
+++ b/.changeset/audit-log-ux-overhaul.md
@@ -1,0 +1,5 @@
+---
+"@shelve/app": minor
+---
+
+Improve audit log UX with enriched API responses, timeline UI, expanded event coverage, and human-readable token scope labels.

--- a/apps/lp/content/docs/2.core-features/audit-logs.md
+++ b/apps/lp/content/docs/2.core-features/audit-logs.md
@@ -3,29 +3,19 @@ title: Audit Logs
 description: Review every privileged action performed on your teams, projects, and secrets.
 ---
 
-Every security-relevant action in Shelve is recorded in an append-only audit log. The feed is scoped to a team and visible to members with at least the required role.
+Every security-relevant action in Shelve is recorded in an append-only audit log. The feed is scoped to a team and visible from **Team → Audit logs**.
 
 ## What gets logged
 
 Among others:
 
-- `team.create`, `team.update`, `team.delete`, `team.member.add`, `team.member.role.update`, `team.member.remove`
-- `project.create`, `project.update`, `project.delete`
+- `team.member.invite`, `team.member.remove`
+- `project.create`, `project.delete`
 - `environment.create`, `environment.update`, `environment.delete`
-- `variable.create`, `variable.update`, `variable.delete`, `variable.pull`, `variable.sync.github`
+- `variables.read`, `variables.create`, `variables.update`, `variables.delete`
 - `token.create`, `token.delete`
 
-Every entry stores:
-
-- the **actor** (`user` with an id, `token` with the non-secret prefix, or `system` for scheduled jobs);
-- the **IP** (respecting the `X-Forwarded-For` chain on serverless / edge hosts);
-- the **user agent** (truncated to 256 chars);
-- the **resource** type and id;
-- an opaque **metadata** JSON blob — for example `{ "scopes": { "permissions": ["read"] } }` on `token.create` or `{ "count": 4 }` on `variable.create`.
-
-::callout{type="info"}
-Audit writes are fire-and-forget: they never block the originating request. If recording fails, the event is logged to the application logs and the request still succeeds.
-::
+Every entry stores the actor, IP, user agent, resource type/id, and a metadata JSON blob. The API enriches each row with human-readable labels — project and environment names, token prefix, user display name — so clients do not need extra lookups.
 
 ## API
 
@@ -48,11 +38,45 @@ curl https://app.shelve.cloud/api/teams/<slug>/audit-logs \
   ::
 
   ::field{name="action" type="string"}
-  Filter by action name (for example `variable.create`). Exact match.
+  Filter by action name (for example `variables.create`). Exact match.
+  ::
+
+  ::field{name="actorType" type="string"}
+  Filter by actor type: `user`, `token`, or `system`.
+  ::
+
+  ::field{name="projectId" type="number"}
+  Filter to events tied to a project (direct resource or metadata).
   ::
 ::
 
-The response includes a `nextCursor` field — pass it back to fetch the next page until it is `null`.
+### Response shape
+
+Each log entry includes enriched fields:
+
+```json
+{
+  "logs": [
+    {
+      "id": 42,
+      "action": "variables.read",
+      "summary": "Read secrets from web-platform / production",
+      "actor": { "type": "token", "label": "she_abc… · ci-deploy" },
+      "resource": { "type": "environment", "label": "web-platform / production", "href": "/my-team/projects/13" },
+      "client": { "label": "Shelve CLI · macOS", "icon": "lucide:terminal", "raw": "..." },
+      "metadata": { "projectId": 13, "projectName": "web-platform", "environmentName": "production" }
+    }
+  ],
+  "nextCursor": 41,
+  "total": 128
+}
+```
+
+Pass `nextCursor` back to fetch the next page until it is `null`.
+
+::callout{type="info"}
+Audit writes are fire-and-forget: they never block the originating request. If recording fails, the event is logged to the application logs and the request still succeeds.
+::
 
 ## Retention
 

--- a/apps/shelve/app/components/audit/LogDetail.vue
+++ b/apps/shelve/app/components/audit/LogDetail.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import type { AuditLogEntry } from '@types'
+
+const props = defineProps<{
+  entry: AuditLogEntry | null
+}>()
+
+const open = defineModel<boolean>('open', { default: false })
+
+const hasMetadata = computed(() => {
+  const meta = props.entry?.metadata
+  return meta && Object.keys(meta).length > 0
+})
+
+const showRawMetadata = ref(false)
+</script>
+
+<template>
+  <UDrawer
+    v-model:open="open"
+    direction="right"
+    :title="entry?.summary ?? 'Audit log details'"
+    description="Full context for this event"
+  >
+    <template #body>
+      <div v-if="entry" class="flex flex-col gap-5 p-4">
+        <section>
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+            What happened
+          </h3>
+          <p class="text-sm">
+            {{ entry.summary }}
+          </p>
+          <p class="mt-1 font-mono text-xs text-muted">
+            {{ entry.action }}
+          </p>
+        </section>
+
+        <section>
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+            Who
+          </h3>
+          <div class="flex items-center gap-2">
+            <UAvatar
+              v-if="entry.actor.type === 'user' && entry.actor.avatarUrl"
+              :src="entry.actor.avatarUrl"
+              :alt="entry.actor.label"
+              size="sm"
+            />
+            <UIcon
+              v-else-if="entry.actor.type === 'token'"
+              name="lucide:key-round"
+              class="size-5 text-muted"
+            />
+            <UIcon
+              v-else
+              name="lucide:cpu"
+              class="size-5 text-muted"
+            />
+            <div>
+              <p class="text-sm font-medium">
+                {{ entry.actor.label }}
+              </p>
+              <p class="text-xs text-muted capitalize">
+                {{ entry.actor.type }}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section v-if="entry.resource">
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+            Where
+          </h3>
+          <NuxtLink
+            v-if="entry.resource.href"
+            :to="entry.resource.href"
+            class="text-sm text-primary hover:underline"
+          >
+            {{ entry.resource.label }}
+          </NuxtLink>
+          <p v-else class="text-sm">
+            {{ entry.resource.label }}
+          </p>
+        </section>
+
+        <section>
+          <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+            Context
+          </h3>
+          <dl class="space-y-2 text-sm">
+            <div class="flex justify-between gap-4">
+              <dt class="text-muted">
+                When
+              </dt>
+              <dd class="text-right">
+                <DatePopover :date="entry.createdAt" label="When" />
+              </dd>
+            </div>
+            <div v-if="entry.ip" class="flex justify-between gap-4">
+              <dt class="text-muted">
+                IP
+              </dt>
+              <dd class="font-mono text-xs">
+                {{ entry.ip }}
+              </dd>
+            </div>
+            <div v-if="entry.client.raw" class="flex justify-between gap-4">
+              <dt class="text-muted">
+                Client
+              </dt>
+              <dd class="flex items-center gap-1.5 text-xs">
+                <UIcon :name="entry.client.icon" class="size-3.5" />
+                {{ entry.client.label }}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section v-if="hasMetadata">
+          <button
+            type="button"
+            class="flex w-full items-center justify-between text-xs font-medium uppercase tracking-wide text-muted"
+            @click="showRawMetadata = !showRawMetadata"
+          >
+            Raw metadata
+            <UIcon
+              :name="showRawMetadata ? 'lucide:chevron-up' : 'lucide:chevron-down'"
+              class="size-4"
+            />
+          </button>
+          <pre
+            v-if="showRawMetadata"
+            class="mt-2 max-h-48 overflow-auto rounded-md bg-elevated/40 p-2 text-xs font-mono whitespace-pre-wrap break-all"
+          >{{ JSON.stringify(entry.metadata, null, 2) }}</pre>
+        </section>
+      </div>
+    </template>
+  </UDrawer>
+</template>

--- a/apps/shelve/app/components/audit/LogDetail.vue
+++ b/apps/shelve/app/components/audit/LogDetail.vue
@@ -13,6 +13,10 @@ const hasMetadata = computed(() => {
 })
 
 const showRawMetadata = ref(false)
+
+watch(() => props.entry?.id, () => {
+  showRawMetadata.value = false
+})
 </script>
 
 <template>

--- a/apps/shelve/app/components/audit/LogEntry.vue
+++ b/apps/shelve/app/components/audit/LogEntry.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import type { AuditLogEntry } from '@types'
+
+defineProps<{
+  entry: AuditLogEntry
+}>()
+
+defineEmits<{
+  select: []
+}>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="group flex w-full items-start gap-3 rounded-lg px-3 py-3 text-left transition-colors hover:bg-elevated/50"
+    @click="$emit('select')"
+  >
+    <div
+      class="flex size-8 shrink-0 items-center justify-center rounded-md bg-elevated/60"
+    >
+      <UIcon :name="entry.actionIcon" class="size-4" :class="entry.actionColor" />
+    </div>
+
+    <div class="min-w-0 flex-1">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 text-sm">
+            <UAvatar
+              v-if="entry.actor.type === 'user' && entry.actor.avatarUrl"
+              :src="entry.actor.avatarUrl"
+              :alt="entry.actor.label"
+              size="2xs"
+            />
+            <UIcon
+              v-else-if="entry.actor.type === 'token'"
+              name="lucide:key-round"
+              class="size-3.5 text-muted"
+            />
+            <span class="font-medium truncate">{{ entry.actor.label }}</span>
+            <span class="text-muted shrink-0">·</span>
+            <span class="text-xs text-muted capitalize">{{ entry.actor.type }}</span>
+          </div>
+          <p class="mt-0.5 text-sm text-default">
+            {{ entry.summary }}
+          </p>
+          <div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted">
+            <NuxtLink
+              v-if="entry.resource?.href"
+              :to="entry.resource.href"
+              class="hover:text-default hover:underline"
+              @click.stop
+            >
+              {{ entry.resource.label }}
+            </NuxtLink>
+            <span v-else-if="entry.resource">{{ entry.resource.label }}</span>
+            <template v-if="entry.ip">
+              <span>·</span>
+              <span class="font-mono">{{ entry.ip }}</span>
+            </template>
+            <template v-if="entry.client.raw">
+              <span>·</span>
+              <span class="inline-flex items-center gap-1">
+                <UIcon :name="entry.client.icon" class="size-3" />
+                {{ entry.client.label }}
+              </span>
+            </template>
+          </div>
+        </div>
+        <div class="flex shrink-0 items-center gap-2 pt-0.5">
+          <DatePopover :date="entry.createdAt" label="When" />
+          <UIcon
+            name="lucide:chevron-right"
+            class="size-4 text-muted opacity-0 transition-opacity group-hover:opacity-100"
+          />
+        </div>
+      </div>
+    </div>
+  </button>
+</template>

--- a/apps/shelve/app/components/audit/LogEntry.vue
+++ b/apps/shelve/app/components/audit/LogEntry.vue
@@ -5,16 +5,29 @@ defineProps<{
   entry: AuditLogEntry
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   select: []
 }>()
+
+function onSelect() {
+  emit('select')
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    onSelect()
+  }
+}
 </script>
 
 <template>
-  <button
-    type="button"
-    class="group flex w-full items-start gap-3 rounded-lg px-3 py-3 text-left transition-colors hover:bg-elevated/50"
-    @click="$emit('select')"
+  <div
+    role="button"
+    tabindex="0"
+    class="group flex w-full cursor-pointer items-start gap-3 rounded-lg px-3 py-3 text-left transition-colors hover:bg-elevated/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    @click="onSelect"
+    @keydown="onKeydown"
   >
     <div
       class="flex size-8 shrink-0 items-center justify-center rounded-md bg-elevated/60"
@@ -76,5 +89,5 @@ defineEmits<{
         </div>
       </div>
     </div>
-  </button>
+  </div>
 </template>

--- a/apps/shelve/app/components/audit/LogFeed.vue
+++ b/apps/shelve/app/components/audit/LogFeed.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { AuditLogEntry } from '@types'
+
+defineProps<{
+  logs: AuditLogEntry[]
+  loading: boolean
+  hasFilters: boolean
+}>()
+
+defineEmits<{
+  select: [entry: AuditLogEntry]
+}>()
+</script>
+
+<template>
+  <div class="rounded-lg border border-default overflow-hidden">
+    <div v-if="loading && !logs.length" class="flex items-center justify-center py-16">
+      <UIcon name="lucide:loader-circle" class="size-6 animate-spin text-muted" />
+    </div>
+
+    <div v-else-if="!logs.length" class="flex flex-col items-center justify-center gap-2 py-16 text-center">
+      <UIcon name="lucide:scroll-text" class="size-8 text-muted" />
+      <p class="text-sm font-medium">
+        No audit logs yet
+      </p>
+      <p class="text-xs text-muted">
+        {{ hasFilters ? 'Try adjusting your filters.' : 'Sensitive actions will appear here as they happen.' }}
+      </p>
+    </div>
+
+    <ul v-else class="divide-y divide-default">
+      <li v-for="entry in logs" :key="entry.id">
+        <AuditLogEntry :entry @select="$emit('select', entry)" />
+      </li>
+    </ul>
+  </div>
+</template>

--- a/apps/shelve/app/components/audit/LogFilters.vue
+++ b/apps/shelve/app/components/audit/LogFilters.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import type { AuditActorType } from '@types'
+import { AUDIT_ACTIONS } from '@types'
+import type { AuditLogFilters } from '~/composables/useAuditLogs'
+
+const filters = defineModel<AuditLogFilters>({ required: true })
+
+const teamSlug = computed(() => useRoute().params.teamSlug as string)
+const projects = useProjects(teamSlug.value)
+const { fetchProjects } = useProjectsService()
+
+onMounted(() => {
+  if (!projects.value?.length) fetchProjects()
+})
+
+const actionItems = [
+  { label: 'All actions', value: undefined },
+  ...AUDIT_ACTIONS.map(action => ({ label: action, value: action })),
+]
+
+const actorItems = [
+  { label: 'All actors', value: undefined },
+  { label: 'Users', value: 'user' as AuditActorType },
+  { label: 'API tokens', value: 'token' as AuditActorType },
+  { label: 'System', value: 'system' as AuditActorType },
+]
+
+const projectItems = computed(() => [
+  { label: 'All projects', value: undefined },
+  ...(projects.value ?? []).map(p => ({ label: p.name, value: p.id })),
+])
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+    <USelect
+      v-model="filters.action"
+      :items="actionItems"
+      value-key="value"
+      placeholder="Action"
+      class="w-full sm:w-48"
+      size="sm"
+    />
+    <USelect
+      v-model="filters.actorType"
+      :items="actorItems"
+      value-key="value"
+      placeholder="Actor"
+      class="w-full sm:w-40"
+      size="sm"
+    />
+    <USelect
+      v-model="filters.projectId"
+      :items="projectItems"
+      value-key="value"
+      placeholder="Project"
+      class="w-full sm:w-48"
+      size="sm"
+    />
+  </div>
+</template>

--- a/apps/shelve/app/components/token/Scopes.vue
+++ b/apps/shelve/app/components/token/Scopes.vue
@@ -5,6 +5,10 @@ const props = defineProps<{
   token: Token
 }>()
 
+const { scopeLabels, fetchScopeLabels, teamName, projectName, environmentName } = useScopeLabels()
+
+onMounted(() => fetchScopeLabels())
+
 const scopeChips = computed(() => {
   const chips: { label: string; icon: string }[] = []
   const s = props.token.scopes
@@ -15,12 +19,20 @@ const scopeChips = computed(() => {
   return chips
 })
 
+function formatList(ids: number[] | undefined, resolver: (id: number) => string): string | null {
+  if (!ids?.length) return null
+  return ids.map(resolver).join(', ')
+}
+
 const tooltip = computed(() => {
   const s = props.token.scopes
   const lines: string[] = []
-  if (s.teamIds?.length) lines.push(`Teams: ${s.teamIds.join(', ')}`)
-  if (s.projectIds?.length) lines.push(`Projects: ${s.projectIds.join(', ')}`)
-  if (s.environmentIds?.length) lines.push(`Environments: ${s.environmentIds.join(', ')}`)
+  const teams = formatList(s.teamIds, teamName)
+  const projects = formatList(s.projectIds, projectName)
+  const envs = formatList(s.environmentIds, environmentName)
+  if (teams) lines.push(`Teams: ${teams}`)
+  if (projects) lines.push(`Projects: ${projects}`)
+  if (envs) lines.push(`Environments: ${envs}`)
   if (props.token.allowedCidrs?.length) lines.push(`Allowed CIDRs: ${props.token.allowedCidrs.join(', ')}`)
   return lines.join('\n')
 })

--- a/apps/shelve/app/composables/useAuditLogs.ts
+++ b/apps/shelve/app/composables/useAuditLogs.ts
@@ -1,0 +1,72 @@
+import type { AuditActorType, AuditLogEntry, AuditLogResponse } from '@types'
+import { useDebounceFn } from '@vueuse/core'
+
+export type AuditLogFilters = {
+  action: string | undefined
+  actorType: AuditActorType | undefined
+  projectId: number | undefined
+}
+
+export function useAuditLogs(teamSlug: Ref<string> | ComputedRef<string>) {
+  const logs = ref<AuditLogEntry[]>([])
+  const loading = ref(false)
+  const loadingMore = ref(false)
+  const cursor = ref<number | null>(null)
+  const hasMore = ref(false)
+  const total = ref(0)
+
+  const filters = reactive<AuditLogFilters>({
+    action: undefined,
+    actorType: undefined,
+    projectId: undefined,
+  })
+
+  async function fetchLogs(reset = false) {
+    if (reset) {
+      loading.value = true
+      cursor.value = null
+    } else {
+      loadingMore.value = true
+    }
+
+    try {
+      const query: Record<string, string | number> = { limit: 50 }
+      if (filters.action) query.action = filters.action
+      if (filters.actorType) query.actorType = filters.actorType
+      if (filters.projectId) query.projectId = filters.projectId
+      if (!reset && cursor.value) query.cursor = cursor.value
+
+      const res = await $fetch<AuditLogResponse>(
+        `/api/teams/${toValue(teamSlug)}/audit-logs`,
+        { query },
+      )
+
+      logs.value = reset ? res.logs : [...logs.value, ...res.logs]
+      cursor.value = res.nextCursor
+      hasMore.value = res.nextCursor !== null
+      total.value = res.total
+    } catch {
+      toast.error('Failed to fetch audit logs')
+    } finally {
+      loading.value = false
+      loadingMore.value = false
+    }
+  }
+
+  const refetch = useDebounceFn(() => fetchLogs(true), 300)
+
+  watch(filters, () => refetch(), { deep: true })
+  watch(teamSlug, () => fetchLogs(true))
+
+  onMounted(() => fetchLogs(true))
+
+  return {
+    logs,
+    loading,
+    loadingMore,
+    hasMore,
+    total,
+    filters,
+    fetchLogs,
+  }
+}

--- a/apps/shelve/app/composables/useAuditLogs.ts
+++ b/apps/shelve/app/composables/useAuditLogs.ts
@@ -14,6 +14,7 @@ export function useAuditLogs(teamSlug: Ref<string> | ComputedRef<string>) {
   const cursor = ref<number | null>(null)
   const hasMore = ref(false)
   const total = ref(0)
+  let requestId = 0
 
   const filters = reactive<AuditLogFilters>({
     action: undefined,
@@ -22,6 +23,8 @@ export function useAuditLogs(teamSlug: Ref<string> | ComputedRef<string>) {
   })
 
   async function fetchLogs(reset = false) {
+    const currentRequestId = ++requestId
+
     if (reset) {
       loading.value = true
       cursor.value = null
@@ -41,15 +44,21 @@ export function useAuditLogs(teamSlug: Ref<string> | ComputedRef<string>) {
         { query },
       )
 
+      if (currentRequestId !== requestId) return
+
       logs.value = reset ? res.logs : [...logs.value, ...res.logs]
       cursor.value = res.nextCursor
       hasMore.value = res.nextCursor !== null
       total.value = res.total
     } catch {
-      toast.error('Failed to fetch audit logs')
+      if (currentRequestId === requestId) {
+        toast.error('Failed to fetch audit logs')
+      }
     } finally {
-      loading.value = false
-      loadingMore.value = false
+      if (currentRequestId === requestId) {
+        loading.value = false
+        loadingMore.value = false
+      }
     }
   }
 

--- a/apps/shelve/app/composables/useScopeLabels.ts
+++ b/apps/shelve/app/composables/useScopeLabels.ts
@@ -1,0 +1,35 @@
+export type ScopeLabels = {
+  teams: Record<number, string>
+  projects: Record<number, string>
+  environments: Record<number, string>
+}
+
+const scopeLabels = useState<ScopeLabels | null>('scope-labels', () => null)
+
+export function useScopeLabels() {
+  async function fetchScopeLabels() {
+    if (scopeLabels.value) return scopeLabels.value
+    scopeLabels.value = await $fetch<ScopeLabels>('/api/user/scope-labels')
+    return scopeLabels.value
+  }
+
+  function teamName(id: number): string {
+    return scopeLabels.value?.teams[id] ?? `team #${id}`
+  }
+
+  function projectName(id: number): string {
+    return scopeLabels.value?.projects[id] ?? `project #${id}`
+  }
+
+  function environmentName(id: number): string {
+    return scopeLabels.value?.environments[id] ?? `env #${id}`
+  }
+
+  return {
+    scopeLabels,
+    fetchScopeLabels,
+    teamName,
+    projectName,
+    environmentName,
+  }
+}

--- a/apps/shelve/app/composables/useScopeLabels.ts
+++ b/apps/shelve/app/composables/useScopeLabels.ts
@@ -4,9 +4,9 @@ export type ScopeLabels = {
   environments: Record<number, string>
 }
 
-const scopeLabels = useState<ScopeLabels | null>('scope-labels', () => null)
-
 export function useScopeLabels() {
+  const scopeLabels = useState<ScopeLabels | null>('scope-labels', () => null)
+
   async function fetchScopeLabels() {
     if (scopeLabels.value) return scopeLabels.value
     scopeLabels.value = await $fetch<ScopeLabels>('/api/user/scope-labels')

--- a/apps/shelve/app/pages/[teamSlug]/team.vue
+++ b/apps/shelve/app/pages/[teamSlug]/team.vue
@@ -43,6 +43,17 @@ const activeTab = computed({
   }
 })
 
+const sectionDescription = computed(() => {
+  switch (activeTab.value) {
+    case 'audit-logs':
+      return 'Review every sensitive action across this team.'
+    case 'settings':
+      return 'Manage team settings and preferences.'
+    default:
+      return 'Manage team members and settings'
+  }
+})
+
 useSeoMeta({
   titleTemplate: () => `%s - ${currentTeam.value.name} Team - Shelve`
 })
@@ -51,7 +62,7 @@ useSeoMeta({
 <template>
   <PageSection
     title="Team"
-    description="Manage team members and settings"
+    :description="sectionDescription"
     :image="currentTeam?.logo"
   >
     <UTabs v-model="activeTab" :items variant="link" class="w-full mb-2" />

--- a/apps/shelve/app/pages/[teamSlug]/team/audit-logs.vue
+++ b/apps/shelve/app/pages/[teamSlug]/team/audit-logs.vue
@@ -1,215 +1,64 @@
 <script setup lang="ts">
-import type { TableColumn } from '@nuxt/ui'
-import type { AuditLog, AuditActorType } from '@types'
-import { parseUserAgent } from '~/utils/userAgent'
+import type { AuditLogEntry } from '@types'
 
 const route = useRoute()
 const teamSlug = computed(() => route.params.teamSlug as string)
 
-const logs = ref<AuditLog[]>([])
-const loading = ref(false)
-const filterAction = ref('')
-const cursor = ref<number | null>(null)
-const hasMore = ref(false)
+const {
+  logs,
+  loading,
+  loadingMore,
+  hasMore,
+  total,
+  filters,
+  fetchLogs,
+} = useAuditLogs(teamSlug)
 
-const columns: TableColumn<AuditLog>[] = [
-  { accessorKey: 'createdAt', header: 'When' },
-  { accessorKey: 'actorType', header: 'Actor' },
-  { accessorKey: 'action', header: 'Action' },
-  { accessorKey: 'resourceType', header: 'Resource' },
-  { accessorKey: 'ip', header: 'IP' },
-  { accessorKey: 'userAgent', header: 'Client' },
-  { accessorKey: 'metadata', header: '' },
-]
+const selectedEntry = ref<AuditLogEntry | null>(null)
+const detailOpen = ref(false)
 
-async function fetchLogs(reset = false) {
-  loading.value = true
-  try {
-    const query: Record<string, string | number> = { limit: 50 }
-    if (filterAction.value) query.action = filterAction.value
-    if (!reset && cursor.value) query.cursor = cursor.value
-    const res = await $fetch<{ logs: AuditLog[]; nextCursor: number | null }>(
-      `/api/teams/${teamSlug.value}/audit-logs`,
-      { query }
-    )
-    logs.value = reset ? res.logs : [...logs.value, ...res.logs]
-    cursor.value = res.nextCursor
-    hasMore.value = res.nextCursor !== null
-  } catch {
-    toast.error('Failed to fetch audit logs')
-  } finally {
-    loading.value = false
-  }
+const hasFilters = computed(() =>
+  Boolean(filters.action || filters.actorType || filters.projectId),
+)
+
+function openDetail(entry: AuditLogEntry) {
+  selectedEntry.value = entry
+  detailOpen.value = true
 }
-
-watch(filterAction, () => {
-  cursor.value = null
-  fetchLogs(true)
-})
-
-const actorMeta: Record<AuditActorType, { color: 'warning' | 'neutral' | 'info'; icon: string }> = {
-  token: { color: 'warning', icon: 'lucide:key-round' },
-  user: { color: 'neutral', icon: 'lucide:user-round' },
-  system: { color: 'info', icon: 'lucide:cpu' },
-}
-
-type ActionColor = 'success' | 'error' | 'warning' | 'info' | 'neutral'
-
-function actionColor(action: string): ActionColor {
-  if (action.endsWith('.create') || action.endsWith('.invite')) return 'success'
-  if (action.endsWith('.delete') || action.endsWith('.remove')) return 'error'
-  if (action.endsWith('.update') || action.startsWith('token.')) return 'warning'
-  if (action.startsWith('auth.')) return 'info'
-  return 'neutral'
-}
-
-const resourceIcons: Record<string, string> = {
-  variable: 'lucide:variable',
-  variables: 'lucide:variable',
-  environment: 'lucide:layers',
-  project: 'lucide:folder',
-  team: 'lucide:users',
-  token: 'lucide:key-round',
-  user: 'lucide:user-round',
-}
-
-function resourceIcon(type: string | null) {
-  if (!type) return 'lucide:circle-dashed'
-  return resourceIcons[type.toLowerCase()] ?? 'lucide:circle'
-}
-
-function hasMetadata(log: AuditLog) {
-  return log.metadata && Object.keys(log.metadata).length > 0
-}
-
-fetchLogs(true)
 
 useSeoMeta({ title: 'Audit logs' })
 </script>
 
 <template>
-  <PageSection
-    title="Audit logs"
-    description="Every sensitive action across this team — token rotation, secret reads/writes, environment changes."
-  >
-    <UTable
-      :columns
-      :data="logs"
+  <div class="flex flex-col gap-4">
+    <p class="text-sm text-muted">
+      Every sensitive action across this team — token rotation, secret reads/writes, environment changes.
+    </p>
+
+    <AuditLogFilters v-model="filters" />
+
+    <AuditLogFeed
+      :logs
       :loading
-      :ui="{
-        base: 'w-full border-separate border-spacing-0',
-        thead: '[&>tr]:bg-elevated/50 [&>tr]:after:content-none',
-        tbody: '[&>tr]:last:[&>td]:border-b-0',
-        th: 'first:rounded-l-lg last:rounded-r-lg border-y border-default first:border-l last:border-r text-xs font-medium uppercase tracking-wide text-muted',
-        td: 'border-b border-default py-2.5 align-middle',
-      }"
-    >
-      <template #createdAt-cell="{ row }">
-        <DatePopover :date="row.original.createdAt" label="When" />
-      </template>
+      :has-filters
+      @select="openDetail"
+    />
 
-      <template #actorType-cell="{ row }">
-        <UBadge
-          :color="actorMeta[row.original.actorType as AuditActorType]?.color ?? 'neutral'"
-          variant="subtle"
-          size="sm"
-          :icon="actorMeta[row.original.actorType as AuditActorType]?.icon"
-          class="font-medium"
-        >
-          {{ row.original.actorType }}
-        </UBadge>
-      </template>
-
-      <template #action-cell="{ row }">
-        <UBadge
-          :color="actionColor(row.original.action)"
-          variant="soft"
-          size="sm"
-          class="font-mono text-xs"
-        >
-          {{ row.original.action }}
-        </UBadge>
-      </template>
-
-      <template #resourceType-cell="{ row }">
-        <div v-if="row.original.resourceType" class="flex items-center gap-1.5 text-sm">
-          <UIcon :name="resourceIcon(row.original.resourceType)" class="size-4 text-muted" />
-          <span>{{ row.original.resourceType }}</span>
-          <span v-if="row.original.resourceId" class="text-xs text-muted font-mono">
-            #{{ row.original.resourceId }}
-          </span>
-        </div>
-        <span v-else class="text-sm text-muted">—</span>
-      </template>
-
-      <template #ip-cell="{ row }">
-        <span v-if="row.original.ip" class="font-mono text-xs text-muted bg-elevated/40 rounded px-1.5 py-0.5">
-          {{ row.original.ip }}
-        </span>
-        <span v-else class="text-sm text-muted">—</span>
-      </template>
-
-      <template #userAgent-cell="{ row }">
-        <UTooltip
-          v-if="row.original.userAgent"
-          :text="row.original.userAgent"
-          :delay-duration="100"
-          :content="{ side: 'top', align: 'start' }"
-        >
-          <span class="inline-flex items-center gap-1.5 text-sm text-muted">
-            <UIcon :name="parseUserAgent(row.original.userAgent)?.icon ?? 'lucide:globe'" class="size-3.5" />
-            <span class="truncate max-w-40">{{ parseUserAgent(row.original.userAgent)?.label ?? row.original.userAgent }}</span>
-          </span>
-        </UTooltip>
-        <span v-else class="text-sm text-muted">—</span>
-      </template>
-
-      <template #metadata-cell="{ row }">
-        <UPopover v-if="hasMetadata(row.original)" arrow :content="{ side: 'left' }">
-          <UButton
-            icon="lucide:braces"
-            color="neutral"
-            variant="ghost"
-            size="xs"
-            aria-label="View metadata"
-          />
-          <template #content>
-            <div class="max-w-sm p-3">
-              <p class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
-                Metadata
-              </p>
-              <pre class="max-h-72 overflow-auto rounded-md bg-elevated/40 p-2 text-xs font-mono whitespace-pre-wrap break-all">{{ JSON.stringify(row.original.metadata, null, 2) }}</pre>
-            </div>
-          </template>
-        </UPopover>
-      </template>
-
-      <template #empty>
-        <div class="flex flex-col items-center justify-center gap-2 py-12 text-center">
-          <UIcon name="lucide:scroll-text" class="size-8 text-muted" />
-          <p class="text-sm font-medium">
-            No audit logs yet
-          </p>
-          <p class="text-xs text-muted">
-            {{ filterAction ? 'Try clearing the filter.' : 'Sensitive actions will appear here as they happen.' }}
-          </p>
-        </div>
-      </template>
-    </UTable>
-
-    <div v-if="hasMore" class="mt-4 flex justify-center">
-      <UButton size="sm" :loading variant="subtle" @click="fetchLogs(false)">
+    <div class="flex flex-col items-center gap-2 sm:flex-row sm:justify-between">
+      <p class="text-xs text-muted">
+        Showing {{ logs.length }} of {{ total }} event{{ total === 1 ? '' : 's' }}
+      </p>
+      <UButton
+        v-if="hasMore"
+        size="sm"
+        variant="subtle"
+        :loading="loadingMore"
+        @click="fetchLogs(false)"
+      >
         Load more
       </UButton>
     </div>
 
-    <template #actions>
-      <UInput
-        v-model="filterAction"
-        size="sm"
-        icon="lucide:filter"
-        placeholder="Filter by action (e.g. token.create)"
-      />
-    </template>
-  </PageSection>
+    <AuditLogDetail v-model:open="detailOpen" :entry="selectedEntry" />
+  </div>
 </template>

--- a/apps/shelve/server/api/teams/[slug]/audit-logs/index.get.ts
+++ b/apps/shelve/server/api/teams/[slug]/audit-logs/index.get.ts
@@ -1,31 +1,58 @@
 import { z } from 'zod'
-import type { AuditLog } from '@types'
+import type { AuditLogResponse } from '@types'
+import { sql } from 'drizzle-orm'
 
 const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
   cursor: z.coerce.number().int().positive().optional(),
   action: z.string().min(1).max(64).optional(),
+  actorType: z.enum(['user', 'token', 'system']).optional(),
+  projectId: z.coerce.number().int().positive().optional(),
 })
 
-export default defineEventHandler(async (event): Promise<{ logs: AuditLog[]; nextCursor: number | null }> => {
+export default defineEventHandler(async (event): Promise<AuditLogResponse> => {
   const slug = await getTeamSlugFromEvent(event)
   const { team } = await requireUserTeam(event, slug)
-  const { limit, cursor, action } = await getValidatedQuery(event, querySchema.parse)
+  const { limit, cursor, action, actorType, projectId } = await getValidatedQuery(event, querySchema.parse)
 
   await requireTokenScope(event, { teamId: team.id, permission: 'read' })
 
   const conditions = [eq(schema.auditLogs.teamId, team.id)]
   if (cursor) conditions.push(lt(schema.auditLogs.id, cursor))
   if (action) conditions.push(eq(schema.auditLogs.action, action))
+  if (actorType) conditions.push(eq(schema.auditLogs.actorType, actorType))
+  if (projectId) {
+    conditions.push(
+      or(
+        and(
+          eq(schema.auditLogs.resourceType, 'project'),
+          eq(schema.auditLogs.resourceId, String(projectId)),
+        ),
+        sql`${schema.auditLogs.metadata}->>'projectId' = ${String(projectId)}`,
+      )!,
+    )
+  }
+
+  const where = and(...conditions)
+
+  const [countRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.auditLogs)
+    .where(where)
 
   const rows = await db.select()
     .from(schema.auditLogs)
-    .where(and(...conditions))
+    .where(where)
     .orderBy(desc(schema.auditLogs.id))
     .limit(limit + 1)
 
-  const logs = rows.slice(0, limit) as AuditLog[]
+  const logs = rows.slice(0, limit)
   const nextCursor = rows.length > limit ? rows[limit - 1]!.id : null
+  const enriched = await enrichAuditLogs(logs, slug)
 
-  return { logs, nextCursor }
+  return {
+    logs: enriched,
+    nextCursor,
+    total: countRow?.count ?? 0,
+  }
 })

--- a/apps/shelve/server/api/teams/[slug]/audit-logs/index.get.ts
+++ b/apps/shelve/server/api/teams/[slug]/audit-logs/index.get.ts
@@ -17,12 +17,11 @@ export default defineEventHandler(async (event): Promise<AuditLogResponse> => {
 
   await requireTokenScope(event, { teamId: team.id, permission: 'read' })
 
-  const conditions = [eq(schema.auditLogs.teamId, team.id)]
-  if (cursor) conditions.push(lt(schema.auditLogs.id, cursor))
-  if (action) conditions.push(eq(schema.auditLogs.action, action))
-  if (actorType) conditions.push(eq(schema.auditLogs.actorType, actorType))
+  const baseConditions = [eq(schema.auditLogs.teamId, team.id)]
+  if (action) baseConditions.push(eq(schema.auditLogs.action, action))
+  if (actorType) baseConditions.push(eq(schema.auditLogs.actorType, actorType))
   if (projectId) {
-    conditions.push(
+    baseConditions.push(
       or(
         and(
           eq(schema.auditLogs.resourceType, 'project'),
@@ -33,22 +32,25 @@ export default defineEventHandler(async (event): Promise<AuditLogResponse> => {
     )
   }
 
-  const where = and(...conditions)
+  const where = and(...baseConditions)
 
   const [countRow] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(schema.auditLogs)
     .where(where)
 
+  const pageConditions = [...baseConditions]
+  if (cursor) pageConditions.push(lt(schema.auditLogs.id, cursor))
+
   const rows = await db.select()
     .from(schema.auditLogs)
-    .where(where)
+    .where(and(...pageConditions))
     .orderBy(desc(schema.auditLogs.id))
     .limit(limit + 1)
 
   const logs = rows.slice(0, limit)
   const nextCursor = rows.length > limit ? rows[limit - 1]!.id : null
-  const enriched = await enrichAuditLogs(logs, slug)
+  const enriched = await enrichAuditLogs(logs, slug, team.id)
 
   return {
     logs: enriched,

--- a/apps/shelve/server/api/teams/[slug]/environments/[id].delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/environments/[id].delete.ts
@@ -7,10 +7,23 @@ export default defineEventHandler(async (event) => {
 
   const { id } = await getValidatedRouterParams(event, idParamsSchema.parse)
 
+  const environment = await db.query.environments.findFirst({
+    where: and(eq(schema.environments.id, id), eq(schema.environments.teamId, team.id)),
+  })
+  if (!environment) throw createError({ statusCode: 404, statusMessage: 'Environment not found' })
+
   await db.delete(schema.environments)
     .where(eq(schema.environments.id, id))
 
   await clearCache('Environments', team.id)
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'environment.delete',
+    resourceType: 'environment',
+    resourceId: id,
+    metadata: { name: environment.name },
+  })
 
   return {
     statusCode: 204,

--- a/apps/shelve/server/api/teams/[slug]/environments/[id].delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/environments/[id].delete.ts
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event) => {
 
   await clearCache('Environments', team.id)
 
-  await logAudit(event, {
+  void logAudit(event, {
     teamId: team.id,
     action: 'environment.delete',
     resourceType: 'environment',

--- a/apps/shelve/server/api/teams/[slug]/environments/[id].put.ts
+++ b/apps/shelve/server/api/teams/[slug]/environments/[id].put.ts
@@ -13,7 +13,15 @@ export default defineEventHandler(async (event) => {
   const { id } = await getValidatedRouterParams(event, idParamsSchema.parse)
   const { name } = await readValidatedBody(event, updateEnvironmentSchema.parse)
 
-  await new EnvironmentsService().updateEnvironment({ id, teamId: team.id, name })
+  const environment = await new EnvironmentsService().updateEnvironment({ id, teamId: team.id, name })
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'environment.update',
+    resourceType: 'environment',
+    resourceId: environment.id,
+    metadata: { name: environment.name },
+  })
 
   return {
     statusCode: 204,

--- a/apps/shelve/server/api/teams/[slug]/environments/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/environments/index.post.ts
@@ -11,7 +11,15 @@ export default defineEventHandler(async (event) => {
 
   const { name } = await readValidatedBody(event, createEnvironmentSchema.parse)
 
-  await new EnvironmentsService().createEnvironment({ name, teamId: team.id })
+  const environment = await new EnvironmentsService().createEnvironment({ name, teamId: team.id })
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'environment.create',
+    resourceType: 'environment',
+    resourceId: environment.id,
+    metadata: { name: environment.name },
+  })
 
   return {
     statusCode: 201,

--- a/apps/shelve/server/api/teams/[slug]/invitations/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/invitations/index.post.ts
@@ -34,5 +34,12 @@ export default eventHandler(async (event: H3Event) => {
     inviteUrl,
   })
 
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'team.member.invite',
+    resourceType: 'user',
+    metadata: { email, role },
+  })
+
   return invitation
 })

--- a/apps/shelve/server/api/teams/[slug]/members/[id].delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/members/[id].delete.ts
@@ -7,10 +7,27 @@ export default eventHandler(async (event) => {
 
   const { id } = await getValidatedRouterParams(event, idParamsSchema.parse)
 
+  const member = await db.query.members.findFirst({
+    where: and(eq(schema.members.id, id), eq(schema.members.teamId, team.id)),
+    with: { user: true },
+  })
+  if (!member) throw createError({ statusCode: 404, statusMessage: 'Member not found' })
+
   await new MembersService().removeMember({
     teamId: team.id,
     slug: team.slug,
     memberId: id,
+  })
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'team.member.remove',
+    resourceType: 'user',
+    resourceId: member.userId,
+    metadata: {
+      email: member.user.email,
+      username: member.user.username,
+    },
   })
 
   return {

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.delete.ts
@@ -7,7 +7,17 @@ export default eventHandler(async (event) => {
 
   const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
 
+  const project = await new ProjectsService().getProject(projectId)
+
   await new ProjectsService().deleteProject(projectId, team.id)
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'project.delete',
+    resourceType: 'project',
+    resourceId: projectId,
+    metadata: { name: project.name },
+  })
 
   return {
     statusCode: 200,

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.delete.ts
@@ -1,12 +1,32 @@
 import { TeamRole } from '@types'
-import { variableIdParamsSchema } from '~~/server/db/zod'
+import { projectIdParamsSchema, variableIdParamsSchema } from '~~/server/db/zod'
 
 export default eventHandler(async (event) => {
   const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug, { minRole: TeamRole.OWNER })
+  const { team } = await requireUserTeam(event, slug, { minRole: TeamRole.OWNER })
   const { variableId } = await getValidatedRouterParams(event, variableIdParamsSchema.parse)
+  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+
+  const existing = await db.query.variables.findFirst({
+    where: eq(schema.variables.id, variableId),
+  })
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Variable not found' })
+
+  const project = await new ProjectsService().getProject(projectId)
 
   await new VariablesService(event).deleteVariable(variableId)
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'variables.delete',
+    resourceType: 'variable',
+    resourceId: variableId,
+    metadata: {
+      key: existing.key,
+      projectId,
+      projectName: project.name,
+    },
+  })
 
   return {
     statusCode: 200,

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.delete.ts
@@ -8,22 +8,25 @@ export default eventHandler(async (event) => {
   const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
 
   const existing = await db.query.variables.findFirst({
-    where: eq(schema.variables.id, variableId),
+    where: and(
+      eq(schema.variables.id, variableId),
+      eq(schema.variables.projectId, projectId),
+    ),
   })
   if (!existing) throw createError({ statusCode: 404, statusMessage: 'Variable not found' })
 
-  const project = await new ProjectsService().getProject(projectId)
+  const project = await new ProjectsService().getProject(existing.projectId)
 
   await new VariablesService(event).deleteVariable(variableId)
 
-  await logAudit(event, {
+  void logAudit(event, {
     teamId: team.id,
     action: 'variables.delete',
     resourceType: 'variable',
     resourceId: variableId,
     metadata: {
       key: existing.key,
-      projectId,
+      projectId: existing.projectId,
       projectName: project.name,
     },
   })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
@@ -24,7 +24,15 @@ export default eventHandler(async (event) => {
   const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
   const body = await readValidatedBody(event, updateVariableSchema.parse)
 
-  const project = await new ProjectsService().getProject(projectId)
+  const existing = await db.query.variables.findFirst({
+    where: and(
+      eq(schema.variables.id, variableId),
+      eq(schema.variables.projectId, projectId),
+    ),
+  })
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Variable not found' })
+
+  const project = await new ProjectsService().getProject(existing.projectId)
   const environmentIds = [...new Set(body.values.map(v => v.environmentId))]
   await assertPushAllowedForEnvironmentIds(environmentIds, team.id, project.syncPolicy)
 
@@ -37,14 +45,14 @@ export default eventHandler(async (event) => {
     autoUppercase: body.autoUppercase,
   })
 
-  await logAudit(event, {
+  void logAudit(event, {
     teamId: team.id,
     action: 'variables.update',
     resourceType: 'variable',
     resourceId: variableId,
     metadata: {
       key: body.autoUppercase ? body.key.toUpperCase() : body.key,
-      projectId,
+      projectId: existing.projectId,
       projectName: project.name,
     },
   })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
@@ -36,6 +36,19 @@ export default eventHandler(async (event) => {
     values: body.values,
     autoUppercase: body.autoUppercase,
   })
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'variables.update',
+    resourceType: 'variable',
+    resourceId: variableId,
+    metadata: {
+      key: body.autoUppercase ? body.key.toUpperCase() : body.key,
+      projectId,
+      projectName: project.name,
+    },
+  })
+
   return {
     statusCode: 200,
     message: 'Variable updated successfully',

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/env/[envId].get.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/env/[envId].get.ts
@@ -21,12 +21,19 @@ export default eventHandler(async (event) => {
 
   const variablesService = new VariablesService(event)
 
+  const project = await new ProjectsService().getProject(projectId)
+  const environmentName = await getEnvironmentName(envId, team.id)
+
   void logAudit(event, {
     teamId: team.id,
     action: 'variables.read',
     resourceType: 'environment',
     resourceId: envId,
-    metadata: { projectId },
+    metadata: {
+      projectId,
+      projectName: project.name,
+      environmentName,
+    },
   })
 
   variablesService.incrementStatAsync(team.id, 'pull')

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.post.ts
@@ -59,6 +59,7 @@ export default eventHandler(async (event) => {
     metadata: {
       keys: body.variables.map(v => v.key),
       environmentIds: body.environmentIds,
+      projectName: project.name,
       syncWithGitHub: body.syncWithGitHub === true,
     },
   })

--- a/apps/shelve/server/api/teams/[slug]/projects/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/index.post.ts
@@ -16,8 +16,18 @@ export default eventHandler(async (event) => {
 
   const body = await readValidatedBody(event, createProjectSchema.parse)
 
-  return await new ProjectsService().createProject({
+  const project = await new ProjectsService().createProject({
     ...body,
     teamId: team.id,
   })
+
+  await logAudit(event, {
+    teamId: team.id,
+    action: 'project.create',
+    resourceType: 'project',
+    resourceId: project.id,
+    metadata: { name: project.name },
+  })
+
+  return project
 })

--- a/apps/shelve/server/api/tokens/[id].delete.ts
+++ b/apps/shelve/server/api/tokens/[id].delete.ts
@@ -14,7 +14,9 @@ export default defineEventHandler(async (event) => {
 
   if (!deletedToken) throw createError({ statusCode: 404, message: `Token not found with id ${id}` })
 
-  await logAudit(event, {
+  const teamIds = await resolveTeamIdsFromTokenScopes(deletedToken.scopes, user.id)
+
+  await logAuditForTeams(event, teamIds, {
     action: 'token.delete',
     resourceType: 'token',
     resourceId: deletedToken.id,

--- a/apps/shelve/server/api/tokens/index.post.ts
+++ b/apps/shelve/server/api/tokens/index.post.ts
@@ -41,7 +41,9 @@ export default defineEventHandler(async (event): Promise<TokenWithSecret> => {
 
   if (!created) throw createError({ statusCode: 500, statusMessage: 'Failed to create token' })
 
-  await logAudit(event, {
+  const teamIds = await resolveTeamIdsFromTokenScopes(created.scopes, user.id)
+
+  await logAuditForTeams(event, teamIds, {
     action: 'token.create',
     resourceType: 'token',
     resourceId: created.id,

--- a/apps/shelve/server/api/user/scope-labels.get.ts
+++ b/apps/shelve/server/api/user/scope-labels.get.ts
@@ -1,4 +1,4 @@
-import { inArray } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 
 export type ScopeLabels = {
   teams: Record<number, string>

--- a/apps/shelve/server/api/user/scope-labels.get.ts
+++ b/apps/shelve/server/api/user/scope-labels.get.ts
@@ -1,0 +1,44 @@
+import { inArray } from 'drizzle-orm'
+
+export type ScopeLabels = {
+  teams: Record<number, string>
+  projects: Record<number, string>
+  environments: Record<number, string>
+}
+
+export default defineEventHandler(async (event): Promise<ScopeLabels> => {
+  const { user } = await requireUserSession(event)
+
+  const memberships = await db.query.members.findMany({
+    where: eq(schema.members.userId, user.id),
+    columns: { teamId: true },
+    with: {
+      team: {
+        columns: { id: true, name: true },
+      },
+    },
+  })
+
+  const teamIds = memberships.map(m => m.teamId)
+  const teams: Record<number, string> = {}
+  for (const m of memberships) teams[m.team.id] = m.team.name
+
+  const projects: Record<number, string> = {}
+  const environments: Record<number, string> = {}
+
+  if (teamIds.length) {
+    const projectRows = await db.query.projects.findMany({
+      where: inArray(schema.projects.teamId, teamIds),
+      columns: { id: true, name: true },
+    })
+    for (const p of projectRows) projects[p.id] = p.name
+
+    const envRows = await db.query.environments.findMany({
+      where: inArray(schema.environments.teamId, teamIds),
+      columns: { id: true, name: true },
+    })
+    for (const e of envRows) environments[e.id] = e.name
+  }
+
+  return { teams, projects, environments }
+})

--- a/apps/shelve/server/middleware/2.auth.ts
+++ b/apps/shelve/server/middleware/2.auth.ts
@@ -23,10 +23,13 @@ export default defineEventHandler(async (event) => {
   if (!bearer) return
 
   try {
-    const { user, scopes } = await authenticateToken(bearer, event)
+    const { user, scopes, token } = await authenticateToken(bearer, event)
     await setUserSession(event, {
       user,
       tokenScopes: scopes,
+      tokenId: token.id,
+      tokenPrefix: token.prefix,
+      tokenName: token.name,
       loggedInAt: new Date(),
     })
     if (legacyCookie) {

--- a/apps/shelve/server/services/audit-enrich.ts
+++ b/apps/shelve/server/services/audit-enrich.ts
@@ -35,7 +35,7 @@ function collectIds(logs: AuditLog[]) {
   return { userIds, tokenIds, projectIds, environmentIds }
 }
 
-async function buildLookupMaps(ids: ReturnType<typeof collectIds>): Promise<LookupMaps> {
+async function buildLookupMaps(ids: ReturnType<typeof collectIds>, teamId: number): Promise<LookupMaps> {
   const users = new Map<number, { username: string; email: string; avatar: string }>()
   const tokens = new Map<number, { name: string; prefix: string }>()
   const projects = new Map<number, { name: string; teamId: number }>()
@@ -59,7 +59,10 @@ async function buildLookupMaps(ids: ReturnType<typeof collectIds>): Promise<Look
 
   if (ids.projectIds.size) {
     const rows = await db.query.projects.findMany({
-      where: inArray(schema.projects.id, [...ids.projectIds]),
+      where: and(
+        inArray(schema.projects.id, [...ids.projectIds]),
+        eq(schema.projects.teamId, teamId),
+      ),
       columns: { id: true, name: true, teamId: true },
     })
     for (const row of rows) projects.set(row.id, row)
@@ -67,7 +70,10 @@ async function buildLookupMaps(ids: ReturnType<typeof collectIds>): Promise<Look
 
   if (ids.environmentIds.size) {
     const rows = await db.query.environments.findMany({
-      where: inArray(schema.environments.id, [...ids.environmentIds]),
+      where: and(
+        inArray(schema.environments.id, [...ids.environmentIds]),
+        eq(schema.environments.teamId, teamId),
+      ),
       columns: { id: true, name: true, teamId: true },
     })
     for (const row of rows) environments.set(row.id, row)
@@ -177,11 +183,12 @@ function actionIcon(action: string): { icon: string; color: string } {
 export async function enrichAuditLogs(
   logs: AuditLog[],
   teamSlug: string,
+  teamId: number,
 ): Promise<AuditLogEntry[]> {
   if (!logs.length) return []
 
   const ids = collectIds(logs)
-  const maps = await buildLookupMaps(ids)
+  const maps = await buildLookupMaps(ids, teamId)
 
   return logs.map((log) => {
     const parsed = parseUserAgent(log.userAgent)

--- a/apps/shelve/server/services/audit-enrich.ts
+++ b/apps/shelve/server/services/audit-enrich.ts
@@ -1,0 +1,204 @@
+import type { AuditLog, AuditLogEntry, AuditActorType } from '@types'
+import { inArray } from 'drizzle-orm'
+import { parseUserAgent } from '~~/server/utils/userAgent'
+import {
+  buildSummary,
+  environmentLabelForAudit as environmentLabel,
+  projectLabelForAudit as projectLabel,
+  type AuditLookupMaps,
+} from '~~/server/utils/audit-present'
+
+type LookupMaps = AuditLookupMaps
+
+function collectIds(logs: AuditLog[]) {
+  const userIds = new Set<number>()
+  const tokenIds = new Set<number>()
+  const projectIds = new Set<number>()
+  const environmentIds = new Set<number>()
+
+  for (const log of logs) {
+    if (log.actorType === 'user' && log.actorId) userIds.add(log.actorId)
+    if (log.actorType === 'token' && log.actorId) tokenIds.add(log.actorId)
+    if (log.resourceType === 'token' && log.resourceId) tokenIds.add(Number(log.resourceId))
+    if (log.resourceType === 'project' && log.resourceId) projectIds.add(Number(log.resourceId))
+    if (log.resourceType === 'environment' && log.resourceId) environmentIds.add(Number(log.resourceId))
+
+    const meta = log.metadata ?? {}
+    if (typeof meta.projectId === 'number') projectIds.add(meta.projectId)
+    if (Array.isArray(meta.environmentIds)) {
+      for (const id of meta.environmentIds) {
+        if (typeof id === 'number') environmentIds.add(id)
+      }
+    }
+  }
+
+  return { userIds, tokenIds, projectIds, environmentIds }
+}
+
+async function buildLookupMaps(ids: ReturnType<typeof collectIds>): Promise<LookupMaps> {
+  const users = new Map<number, { username: string; email: string; avatar: string }>()
+  const tokens = new Map<number, { name: string; prefix: string }>()
+  const projects = new Map<number, { name: string; teamId: number }>()
+  const environments = new Map<number, { name: string; teamId: number }>()
+
+  if (ids.userIds.size) {
+    const rows = await db.query.users.findMany({
+      where: inArray(schema.users.id, [...ids.userIds]),
+      columns: { id: true, username: true, email: true, avatar: true },
+    })
+    for (const row of rows) users.set(row.id, row)
+  }
+
+  if (ids.tokenIds.size) {
+    const rows = await db.query.tokens.findMany({
+      where: inArray(schema.tokens.id, [...ids.tokenIds]),
+      columns: { id: true, name: true, prefix: true },
+    })
+    for (const row of rows) tokens.set(row.id, row)
+  }
+
+  if (ids.projectIds.size) {
+    const rows = await db.query.projects.findMany({
+      where: inArray(schema.projects.id, [...ids.projectIds]),
+      columns: { id: true, name: true, teamId: true },
+    })
+    for (const row of rows) projects.set(row.id, row)
+  }
+
+  if (ids.environmentIds.size) {
+    const rows = await db.query.environments.findMany({
+      where: inArray(schema.environments.id, [...ids.environmentIds]),
+      columns: { id: true, name: true, teamId: true },
+    })
+    for (const row of rows) environments.set(row.id, row)
+  }
+
+  return { users, tokens, projects, environments }
+}
+
+function buildActor(log: AuditLog, maps: LookupMaps): AuditLogEntry['actor'] {
+  const meta = log.metadata ?? {}
+
+  if (log.actorType === 'user' && log.actorId) {
+    const user = maps.users.get(log.actorId)
+    return {
+      type: 'user',
+      label: user?.username ?? user?.email ?? `User #${log.actorId}`,
+      avatarUrl: user?.avatar,
+    }
+  }
+
+  if (log.actorType === 'token') {
+    const token = log.actorId ? maps.tokens.get(log.actorId) : undefined
+    const prefix = (meta.tokenPrefix as string | undefined) ?? token?.prefix
+    const name = (meta.tokenName as string | undefined) ?? token?.name
+    const parts = [prefix, name].filter(Boolean)
+    return {
+      type: 'token',
+      label: parts.length ? parts.join(' · ') : 'API token',
+    }
+  }
+
+  return { type: log.actorType as AuditActorType, label: 'System' }
+}
+
+function buildResource(
+  log: AuditLog,
+  maps: LookupMaps,
+  teamSlug: string,
+): AuditLogEntry['resource'] {
+  if (!log.resourceType) return null
+
+  const resourceId = log.resourceId ? Number(log.resourceId) : undefined
+  const meta = log.metadata ?? {}
+
+  switch (log.resourceType) {
+    case 'project': {
+      const name = projectLabel(resourceId, maps, meta)
+      return {
+        type: 'project',
+        label: name,
+        href: resourceId ? `/${teamSlug}/projects/${resourceId}` : undefined,
+      }
+    }
+    case 'environment': {
+      const projectName = projectLabel(meta.projectId as number | undefined, maps, meta)
+      const envName = environmentLabel(resourceId, maps, meta)
+      const projectId = meta.projectId as number | undefined
+      return {
+        type: 'environment',
+        label: `${projectName} / ${envName}`,
+        href: projectId ? `/${teamSlug}/projects/${projectId}` : `/${teamSlug}/environments`,
+      }
+    }
+    case 'token': {
+      const token = resourceId ? maps.tokens.get(resourceId) : undefined
+      const name = (meta.name as string | undefined) ?? token?.name
+      const prefix = (meta.prefix as string | undefined) ?? token?.prefix
+      return {
+        type: 'token',
+        label: [prefix, name].filter(Boolean).join(' · ') || `token #${resourceId}`,
+        href: '/user/tokens',
+      }
+    }
+    case 'variable':
+      return {
+        type: 'variable',
+        label: String(meta.key ?? `variable #${resourceId}`),
+        href: meta.projectId ? `/${teamSlug}/projects/${meta.projectId}` : undefined,
+      }
+    default:
+      return {
+        type: log.resourceType,
+        label: log.resourceId ? `${log.resourceType} #${log.resourceId}` : log.resourceType,
+      }
+  }
+}
+
+function actionIcon(action: string): { icon: string; color: string } {
+  if (action.endsWith('.delete') || action.endsWith('.remove')) {
+    return { icon: 'lucide:trash-2', color: 'text-error' }
+  }
+  if (action.endsWith('.create') || action.endsWith('.invite')) {
+    return { icon: 'lucide:plus-circle', color: 'text-success' }
+  }
+  if (action.endsWith('.update')) {
+    return { icon: 'lucide:pencil', color: 'text-warning' }
+  }
+  if (action.includes('.read') || action.includes('.pull')) {
+    return { icon: 'lucide:eye', color: 'text-muted' }
+  }
+  if (action.startsWith('token.')) {
+    return { icon: 'lucide:key-round', color: 'text-primary' }
+  }
+  return { icon: 'lucide:activity', color: 'text-muted' }
+}
+
+export async function enrichAuditLogs(
+  logs: AuditLog[],
+  teamSlug: string,
+): Promise<AuditLogEntry[]> {
+  if (!logs.length) return []
+
+  const ids = collectIds(logs)
+  const maps = await buildLookupMaps(ids)
+
+  return logs.map((log) => {
+    const parsed = parseUserAgent(log.userAgent)
+    const { icon, color } = actionIcon(log.action)
+
+    return {
+      ...log,
+      actor: buildActor(log, maps),
+      resource: buildResource(log, maps, teamSlug),
+      client: {
+        label: parsed?.label ?? log.userAgent ?? 'Unknown client',
+        icon: parsed?.icon ?? 'lucide:globe',
+        raw: log.userAgent,
+      },
+      summary: buildSummary(log, maps),
+      actionIcon: icon,
+      actionColor: color,
+    }
+  })
+}

--- a/apps/shelve/server/services/audit.ts
+++ b/apps/shelve/server/services/audit.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
-import type { AuditAction, AuditActorType } from '@types'
+import type { AuditAction, AuditActorType, TokenScopes } from '@types'
+import { inArray } from 'drizzle-orm'
 
 export type AuditEvent = {
   teamId?: number | null
@@ -19,7 +20,14 @@ export async function logAudit(event: H3Event, payload: AuditEvent): Promise<voi
   try {
     const session = await getUserSession(event)
     const actorType: AuditActorType = session.tokenScopes ? 'token' : session.user ? 'user' : 'system'
-    const actorId = session.user?.id ?? null
+    const actorId = session.tokenScopes && session.tokenId
+      ? session.tokenId
+      : session.user?.id ?? null
+
+    const tokenMeta = session.tokenScopes && session.tokenId
+      ? { tokenPrefix: session.tokenPrefix, tokenName: session.tokenName }
+      : {}
+
     const ip = getRequestIP(event, { xForwardedFor: true }) ?? null
     const userAgent = getRequestHeader(event, 'user-agent')?.slice(0, 256) ?? null
 
@@ -32,9 +40,58 @@ export async function logAudit(event: H3Event, payload: AuditEvent): Promise<voi
       resourceId: payload.resourceId !== undefined && payload.resourceId !== null ? String(payload.resourceId) : null,
       ip,
       userAgent,
-      metadata: payload.metadata ?? null,
+      metadata: { ...tokenMeta, ...payload.metadata },
     })
   } catch (err) {
     console.error('[audit] failed to record event', { action: payload.action, err })
   }
+}
+
+/** Writes the same audit event once per team (e.g. token create/delete). */
+export async function logAuditForTeams(
+  event: H3Event,
+  teamIds: number[],
+  payload: Omit<AuditEvent, 'teamId'>,
+): Promise<void> {
+  const uniqueTeamIds = [...new Set(teamIds)]
+  for (const teamId of uniqueTeamIds) {
+    await logAudit(event, { ...payload, teamId })
+  }
+}
+
+export async function getUserTeamIds(userId: number): Promise<number[]> {
+  const memberships = await db.query.members.findMany({
+    where: eq(schema.members.userId, userId),
+    columns: { teamId: true },
+  })
+  return memberships.map(m => m.teamId)
+}
+
+export async function resolveTeamIdsFromTokenScopes(
+  scopes: TokenScopes,
+  userId: number,
+): Promise<number[]> {
+  if (scopes.teamIds?.length) {
+    return scopes.teamIds
+  }
+
+  if (scopes.projectIds?.length) {
+    const projects = await db.query.projects.findMany({
+      where: inArray(schema.projects.id, scopes.projectIds),
+      columns: { teamId: true },
+    })
+    const teamIds = [...new Set(projects.map(p => p.teamId))]
+    if (teamIds.length) return teamIds
+  }
+
+  if (scopes.environmentIds?.length) {
+    const environments = await db.query.environments.findMany({
+      where: inArray(schema.environments.id, scopes.environmentIds),
+      columns: { teamId: true },
+    })
+    const teamIds = [...new Set(environments.map(e => e.teamId))]
+    if (teamIds.length) return teamIds
+  }
+
+  return getUserTeamIds(userId)
 }

--- a/apps/shelve/server/services/audit.ts
+++ b/apps/shelve/server/services/audit.ts
@@ -54,9 +54,13 @@ export async function logAuditForTeams(
   payload: Omit<AuditEvent, 'teamId'>,
 ): Promise<void> {
   const uniqueTeamIds = [...new Set(teamIds)]
-  for (const teamId of uniqueTeamIds) {
-    await logAudit(event, { ...payload, teamId })
-  }
+  await Promise.all(
+    uniqueTeamIds.map(teamId =>
+      logAudit(event, { ...payload, teamId }).catch(err => {
+        console.error('[audit] failed to record team event', { action: payload.action, teamId, err })
+      }),
+    ),
+  )
 }
 
 export async function getUserTeamIds(userId: number): Promise<number[]> {

--- a/apps/shelve/server/services/user.ts
+++ b/apps/shelve/server/services/user.ts
@@ -104,7 +104,7 @@ function generateUniqueUsername(username: string): string {
 export async function authenticateToken(
   rawToken: string,
   event: H3Event
-): Promise<{ user: User; scopes: TokenScopes }> {
+): Promise<{ user: User; scopes: TokenScopes; token: { id: number; prefix: string; name: string } }> {
   if (!rawToken || !rawToken.startsWith('she_')) {
     throw createError({ statusCode: 401, statusMessage: 'Invalid token' })
   }
@@ -138,7 +138,11 @@ export async function authenticateToken(
     .set({ lastUsedAt: new Date(), lastUsedIp: ip })
     .where(eq(schema.tokens.id, token.id))
 
-  return { user, scopes: token.scopes }
+  return {
+    user,
+    scopes: token.scopes,
+    token: { id: token.id, prefix: token.prefix, name: token.name },
+  }
 }
 
 function isIpInCidr(ip: string, cidr: string): boolean {

--- a/apps/shelve/server/utils/audit-present.ts
+++ b/apps/shelve/server/utils/audit-present.ts
@@ -34,9 +34,13 @@ export function buildSummary(log: AuditLog, maps: AuditLookupMaps): string {
       return `Created ${count} variable${count === 1 ? '' : 's'} in ${projectLabel(resourceId, maps, meta)}`
     }
     case 'variables.update':
-      return `Updated variable ${meta.key ?? ''}`.trim() || `Updated variable in ${projectLabel(meta.projectId as number | undefined, maps, meta)}`
+      return meta.key
+        ? `Updated variable ${meta.key}`
+        : `Updated variable in ${projectLabel(meta.projectId as number | undefined, maps, meta)}`
     case 'variables.delete':
-      return `Deleted variable ${meta.key ?? ''}`.trim() || 'Deleted a variable'
+      return meta.key
+        ? `Deleted variable ${meta.key}`
+        : `Deleted a variable in ${projectLabel(meta.projectId as number | undefined, maps, meta)}`
     case 'token.create':
       return `Created API token ${meta.name ?? maps.tokens.get(resourceId!)?.name ?? ''}`.trim()
     case 'token.delete':

--- a/apps/shelve/server/utils/audit-present.ts
+++ b/apps/shelve/server/utils/audit-present.ts
@@ -1,0 +1,69 @@
+import type { AuditLog } from '@types'
+
+export type AuditLookupMaps = {
+  users: Map<number, { username: string; email: string; avatar: string }>
+  tokens: Map<number, { name: string; prefix: string }>
+  projects: Map<number, { name: string; teamId: number }>
+  environments: Map<number, { name: string; teamId: number }>
+}
+
+function projectLabel(id: number | undefined, maps: AuditLookupMaps, meta?: Record<string, unknown>): string {
+  if (meta?.projectName && typeof meta.projectName === 'string') return meta.projectName
+  if (id && maps.projects.has(id)) return maps.projects.get(id)!.name
+  if (id) return `project #${id} (deleted)`
+  return 'project'
+}
+
+function environmentLabel(id: number | undefined, maps: AuditLookupMaps, meta?: Record<string, unknown>): string {
+  if (meta?.environmentName && typeof meta.environmentName === 'string') return meta.environmentName
+  if (id && maps.environments.has(id)) return maps.environments.get(id)!.name
+  if (id) return `environment #${id} (deleted)`
+  return 'environment'
+}
+
+export function buildSummary(log: AuditLog, maps: AuditLookupMaps): string {
+  const meta = log.metadata ?? {}
+  const resourceId = log.resourceId ? Number(log.resourceId) : undefined
+
+  switch (log.action) {
+    case 'variables.read':
+      return `Read secrets from ${projectLabel(meta.projectId as number | undefined, maps, meta)} / ${environmentLabel(resourceId, maps, meta)}`
+    case 'variables.create': {
+      const keys = meta.keys as string[] | undefined
+      const count = keys?.length ?? 0
+      return `Created ${count} variable${count === 1 ? '' : 's'} in ${projectLabel(resourceId, maps, meta)}`
+    }
+    case 'variables.update':
+      return `Updated variable ${meta.key ?? ''}`.trim() || `Updated variable in ${projectLabel(meta.projectId as number | undefined, maps, meta)}`
+    case 'variables.delete':
+      return `Deleted variable ${meta.key ?? ''}`.trim() || 'Deleted a variable'
+    case 'token.create':
+      return `Created API token ${meta.name ?? maps.tokens.get(resourceId!)?.name ?? ''}`.trim()
+    case 'token.delete':
+      return `Deleted API token ${meta.name ?? maps.tokens.get(resourceId!)?.name ?? ''}`.trim()
+    case 'project.create':
+      return `Created project ${meta.name ?? maps.projects.get(resourceId!)?.name ?? ''}`.trim()
+    case 'project.delete':
+      return `Deleted project ${meta.name ?? maps.projects.get(resourceId!)?.name ?? ''}`.trim()
+    case 'environment.create':
+      return `Created environment ${meta.name ?? maps.environments.get(resourceId!)?.name ?? ''}`.trim()
+    case 'environment.update':
+      return `Renamed environment to ${meta.name ?? maps.environments.get(resourceId!)?.name ?? ''}`.trim()
+    case 'environment.delete':
+      return `Deleted environment ${meta.name ?? maps.environments.get(resourceId!)?.name ?? ''}`.trim()
+    case 'team.member.invite':
+      return `Invited ${meta.email ?? 'a member'}`
+    case 'team.member.remove':
+      return `Removed ${meta.email ?? meta.username ?? 'a member'}`
+    default:
+      return log.action.replace(/\./g, ' · ')
+  }
+}
+
+export function projectLabelForAudit(id: number | undefined, maps: AuditLookupMaps, meta?: Record<string, unknown>): string {
+  return projectLabel(id, maps, meta)
+}
+
+export function environmentLabelForAudit(id: number | undefined, maps: AuditLookupMaps, meta?: Record<string, unknown>): string {
+  return environmentLabel(id, maps, meta)
+}

--- a/apps/shelve/server/utils/userAgent.ts
+++ b/apps/shelve/server/utils/userAgent.ts
@@ -4,12 +4,16 @@ export type ParsedUserAgent = {
 }
 
 const KNOWN_CLIENTS: Array<{ pattern: RegExp; label: (m: RegExpMatchArray, ua: string) => string; icon: string }> = [
-  { pattern: /shelve-cli\/([\d.]+|unknown)/i, label: (m, ua) => {
-    if (m[1] !== 'unknown') return `Shelve CLI ${m[1]}`
-    const osMatch = ua.match(/\(([^)]+)\)/)
-    const os = osMatch?.[1]?.split(';')[0]?.trim()
-    return os ? `Shelve CLI · ${os}` : 'Shelve CLI'
-  }, icon: 'lucide:terminal' },
+  {
+    pattern: /shelve-cli\/([\d.]+|unknown)/i,
+    label: (m, ua) => {
+      if (m[1] !== 'unknown') return `Shelve CLI ${m[1]}`
+      const osMatch = ua.match(/\(([^)]+)\)/)
+      const os = osMatch?.[1]?.split(';')[0]?.trim()
+      return os ? `Shelve CLI · ${os}` : 'Shelve CLI'
+    },
+    icon: 'lucide:terminal',
+  },
   { pattern: /^node$/i, label: () => 'Node.js', icon: 'lucide:hexagon' },
   { pattern: /node\/?(v?\d+(?:\.\d+)*)?/i, label: m => (m[1] ? `Node.js ${m[1]}` : 'Node.js'), icon: 'lucide:hexagon' },
   { pattern: /curl\/([\d.]+)/i, label: m => `curl ${m[1]}`, icon: 'lucide:terminal' },

--- a/apps/shelve/shared/types/auth.d.ts
+++ b/apps/shelve/shared/types/auth.d.ts
@@ -26,6 +26,9 @@ declare module '#auth-utils' {
     defaultTeamSlug?: string
     loggedInAt: Date
     tokenScopes?: TokenScopes
+    tokenId?: number
+    tokenPrefix?: string
+    tokenName?: string
   }
 
   interface SecureSessionData {

--- a/apps/shelve/test/e2e/flows/audit-logs.ts
+++ b/apps/shelve/test/e2e/flows/audit-logs.ts
@@ -2,6 +2,22 @@ import { test, expect } from 'vitest'
 import type { AuditLogResponse } from '@types'
 import type { E2EContext } from '../helpers'
 
+async function waitForAuditAction(
+  ctx: E2EContext,
+  action: string,
+  timeoutMs = 5000,
+): Promise<AuditLogResponse> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const feed = await ctx.api<AuditLogResponse>(`/api/teams/${ctx.teamSlug}/audit-logs`)
+    if (feed.logs.some(entry => entry.action === action)) return feed
+    await new Promise(resolve => setTimeout(resolve, 200))
+  }
+
+  throw new Error(`Timed out waiting for audit action "${action}"`)
+}
+
 export function registerAuditLogTests(ctx: E2EContext) {
   test('records a `token.create` event when a token is created', async () => {
     await ctx.api('/api/tokens', {
@@ -9,7 +25,7 @@ export function registerAuditLogTests(ctx: E2EContext) {
       body: { name: 'audited-token' },
     })
 
-    const feed = await ctx.api<AuditLogResponse>(`/api/teams/${ctx.teamSlug}/audit-logs`)
+    const feed = await waitForAuditAction(ctx, 'token.create')
     expect(Array.isArray(feed.logs)).toBe(true)
     expect(feed.logs.some(entry => entry.action === 'token.create')).toBe(true)
     expect(feed.logs[0]?.summary).toBeTruthy()

--- a/apps/shelve/test/e2e/flows/audit-logs.ts
+++ b/apps/shelve/test/e2e/flows/audit-logs.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
-import type { E2EContext } from '../helpers'
 import type { AuditLogResponse } from '@types'
+import type { E2EContext } from '../helpers'
 
 export function registerAuditLogTests(ctx: E2EContext) {
   test('records a `token.create` event when a token is created', async () => {

--- a/apps/shelve/test/e2e/flows/audit-logs.ts
+++ b/apps/shelve/test/e2e/flows/audit-logs.ts
@@ -1,18 +1,6 @@
 import { test, expect } from 'vitest'
 import type { E2EContext } from '../helpers'
-
-type AuditLog = {
-  id: number
-  action: string
-  actorType: 'user' | 'token' | 'system'
-  actorId: number | null
-  resourceType: string | null
-  resourceId: string | null
-  metadata: Record<string, unknown> | null
-  createdAt: string
-}
-
-type AuditResponse = { logs: AuditLog[]; nextCursor: number | null }
+import type { AuditLogResponse } from '@types'
 
 export function registerAuditLogTests(ctx: E2EContext) {
   test('records a `token.create` event when a token is created', async () => {
@@ -21,30 +9,29 @@ export function registerAuditLogTests(ctx: E2EContext) {
       body: { name: 'audited-token' },
     })
 
-    // token.create is team-less by default — logs are per-team, so the broadest
-    // assertion we can make via the public endpoint is that _some_ action took
-    // place on this team during the flow. `variable.create` is written on
-    // every push and is the most reliable marker; we simply check the feed
-    // is non-empty and structurally sound here.
-    const feed = await ctx.api<AuditResponse>(`/api/teams/${ctx.teamSlug}/audit-logs`)
+    const feed = await ctx.api<AuditLogResponse>(`/api/teams/${ctx.teamSlug}/audit-logs`)
     expect(Array.isArray(feed.logs)).toBe(true)
+    expect(feed.logs.some(entry => entry.action === 'token.create')).toBe(true)
+    expect(feed.logs[0]?.summary).toBeTruthy()
+    expect(feed.logs[0]?.actor?.label).toBeTruthy()
   })
 
   test('filters by action', async () => {
-    const feed = await ctx.api<AuditResponse>(
-      `/api/teams/${ctx.teamSlug}/audit-logs?action=variable.create`
+    const feed = await ctx.api<AuditLogResponse>(
+      `/api/teams/${ctx.teamSlug}/audit-logs?action=variables.create`
     )
-    for (const entry of feed.logs) expect(entry.action).toBe('variable.create')
+    for (const entry of feed.logs) expect(entry.action).toBe('variables.create')
   })
 
   test('respects the limit query param', async () => {
-    const feed = await ctx.api<AuditResponse>(`/api/teams/${ctx.teamSlug}/audit-logs?limit=1`)
+    const feed = await ctx.api<AuditLogResponse>(`/api/teams/${ctx.teamSlug}/audit-logs?limit=1`)
     expect(feed.logs.length).toBeLessThanOrEqual(1)
+    expect(typeof feed.total).toBe('number')
   })
 
   test('rejects invalid limit values', async () => {
     await expect(
-      ctx.api<AuditResponse>(`/api/teams/${ctx.teamSlug}/audit-logs?limit=0`)
+      ctx.api<AuditLogResponse>(`/api/teams/${ctx.teamSlug}/audit-logs?limit=0`)
     ).rejects.toMatchObject({ statusCode: 400 })
   })
 }

--- a/apps/shelve/test/unit/audit-enrich.test.ts
+++ b/apps/shelve/test/unit/audit-enrich.test.ts
@@ -5,8 +5,8 @@ import { buildSummary } from '../../server/utils/audit-present'
 const emptyMaps = {
   users: new Map(),
   tokens: new Map(),
-  projects: new Map([ [13, { name: 'web-platform', teamId: 1 }] ]),
-  environments: new Map([ [86, { name: 'production', teamId: 1 }] ]),
+  projects: new Map([[13, { name: 'web-platform', teamId: 1 }]]),
+  environments: new Map([[86, { name: 'production', teamId: 1 }]]),
 }
 
 function log(overrides: Partial<AuditLog>): AuditLog {

--- a/apps/shelve/test/unit/audit-enrich.test.ts
+++ b/apps/shelve/test/unit/audit-enrich.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest'
+import type { AuditLog } from '@types'
+import { buildSummary } from '../../server/utils/audit-present'
+
+const emptyMaps = {
+  users: new Map(),
+  tokens: new Map(),
+  projects: new Map([ [13, { name: 'web-platform', teamId: 1 }] ]),
+  environments: new Map([ [86, { name: 'production', teamId: 1 }] ]),
+}
+
+function log(overrides: Partial<AuditLog>): AuditLog {
+  return {
+    id: 1,
+    teamId: 1,
+    actorType: 'token',
+    actorId: 5,
+    action: 'variables.read',
+    resourceType: 'environment',
+    resourceId: '86',
+    ip: '127.0.0.1',
+    userAgent: 'shelve-cli/5.0.0',
+    metadata: { projectId: 13 },
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+describe('buildSummary', () => {
+  test('describes variable reads with project and environment names', () => {
+    const summary = buildSummary(log({}), emptyMaps)
+    expect(summary).toBe('Read secrets from web-platform / production')
+  })
+
+  test('uses metadata names when present', () => {
+    const summary = buildSummary(log({
+      metadata: { projectId: 13, projectName: 'api', environmentName: 'staging' },
+    }), emptyMaps)
+    expect(summary).toBe('Read secrets from api / staging')
+  })
+
+  test('describes token creation', () => {
+    const summary = buildSummary(log({
+      action: 'token.create',
+      resourceType: 'token',
+      resourceId: '9',
+      metadata: { name: 'ci-deploy' },
+    }), emptyMaps)
+    expect(summary).toBe('Created API token ci-deploy')
+  })
+})

--- a/apps/shelve/test/unit/audit-enrich.test.ts
+++ b/apps/shelve/test/unit/audit-enrich.test.ts
@@ -48,4 +48,14 @@ describe('buildSummary', () => {
     }), emptyMaps)
     expect(summary).toBe('Created API token ci-deploy')
   })
+
+  test('falls back to project context when variable key is missing', () => {
+    const summary = buildSummary(log({
+      action: 'variables.update',
+      resourceType: 'variable',
+      resourceId: '42',
+      metadata: { projectId: 13 },
+    }), emptyMaps)
+    expect(summary).toBe('Updated variable in web-platform')
+  })
 })

--- a/packages/types/src/Audit.ts
+++ b/packages/types/src/Audit.ts
@@ -21,6 +21,7 @@ export type AuditAction =
 export const AUDIT_ACTIONS: AuditAction[] = [
   'token.create',
   'token.delete',
+  'token.use',
   'variables.read',
   'variables.create',
   'variables.update',

--- a/packages/types/src/Audit.ts
+++ b/packages/types/src/Audit.ts
@@ -18,6 +18,22 @@ export type AuditAction =
   | 'auth.login'
   | 'auth.logout'
 
+export const AUDIT_ACTIONS: AuditAction[] = [
+  'token.create',
+  'token.delete',
+  'variables.read',
+  'variables.create',
+  'variables.update',
+  'variables.delete',
+  'environment.create',
+  'environment.update',
+  'environment.delete',
+  'project.create',
+  'project.delete',
+  'team.member.invite',
+  'team.member.remove',
+]
+
 export type AuditLog = {
   id: number
   teamId: number | null
@@ -32,8 +48,25 @@ export type AuditLog = {
   createdAt: Date
 }
 
+export type AuditLogEntry = AuditLog & {
+  actor: { type: AuditActorType; label: string; avatarUrl?: string }
+  resource: { type: string; label: string; href?: string } | null
+  client: { label: string; icon: string; raw: string | null }
+  summary: string
+  actionIcon: string
+  actionColor: string
+}
+
 export type AuditLogQuery = {
   limit?: number
   cursor?: number
   action?: string
+  actorType?: AuditActorType
+  projectId?: number
+}
+
+export type AuditLogResponse = {
+  logs: AuditLogEntry[]
+  nextCursor: number | null
+  total: number
 }


### PR DESCRIPTION
## Summary

- Enrich the audit log API with human-readable labels (`summary`, actor, resource, client) via batch lookups instead of raw IDs
- Replace the badge-heavy table with a timeline UI, responsive filters (action, actor, project), detail drawer, and visible pagination counter
- Fix audit data quality: token actor ID, team-scoped token events, expanded logging on project/env/variable/team mutations
- Resolve token scope tooltips to project/team/environment names instead of numeric IDs

## Test plan

- [ ] Open `/{teamSlug}/team/audit-logs` and verify entries show readable summaries (e.g. `web-platform / production`)
- [ ] Click an entry and confirm the detail drawer shows structured sections + collapsible raw metadata
- [ ] Filter by action, actor type, and project; confirm count updates and Load more works
- [ ] Create/delete a token and confirm `token.create` appears in the team audit feed
- [ ] On `/user/tokens`, hover scoped token chips and verify tooltip shows names not IDs
- [ ] Run `pnpm exec vitest run test/unit/audit-enrich.test.ts` in `apps/shelve`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned audit log interface with an enhanced timeline feed and detailed event viewer
  * Added filtering by action, actor type, and project
  * Enriched metadata displays human-readable names (projects, environments, tokens) instead of IDs
  * Token scope labels now show actual team/project/environment names
  * Updated audit log documentation with expanded event coverage and improved filtering guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/shelve/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->