### PR TITLE
refactor(app): resolve projects within team context on nested routes

### DIFF
--- a/.changeset/team-project-context.md
+++ b/.changeset/team-project-context.md
@@ -1,0 +1,5 @@
+---
+"@shelve/app": patch
+---
+
+Align nested project API handlers with the team from the URL path.

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.delete.ts
@@ -1,21 +1,15 @@
 import { TeamRole } from '@types'
-import { projectIdParamsSchema } from '~~/server/db/zod'
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  const { team } = await requireUserTeam(event, slug, { minRole: TeamRole.OWNER })
+  const { team, project } = await requireUserTeamProject(event, { minRole: TeamRole.OWNER })
 
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
-
-  const project = await new ProjectsService().getProject(projectId)
-
-  await new ProjectsService().deleteProject(projectId, team.id)
+  await new ProjectsService().deleteProject(project.id, team.id)
 
   await logAudit(event, {
     teamId: team.id,
     action: 'project.delete',
     resourceType: 'project',
-    resourceId: projectId,
+    resourceId: project.id,
     metadata: { name: project.name },
   })
 

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.get.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.get.ts
@@ -1,8 +1,4 @@
-import { projectIdParamsSchema } from '~~/server/db/zod'
-
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
-  return await new ProjectsService().getProject(projectId)
+  const { project } = await requireUserTeamProject(event)
+  return project
 })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.put.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/index.put.ts
@@ -15,23 +15,13 @@ const updateProjectSchema = z.object({
   syncPolicy: syncPolicySchema,
 })
 
-const projectIdParamsSchema = z.object({
-  projectId: z.coerce.number({
-    error: 'Project ID is required',
-  }).int().positive(),
-})
-
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  const { team } = await requireUserTeam(event, slug, { minRole: TeamRole.ADMIN })
-
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
-
+  const { team, project } = await requireUserTeamProject(event, { minRole: TeamRole.ADMIN })
   const body = await readValidatedBody(event, updateProjectSchema.parse)
 
   return await new ProjectsService().updateProject({
-    id: projectId,
+    id: project.id,
     ...body,
-    teamId: team.id
+    teamId: team.id,
   })
 })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.delete.ts
@@ -1,12 +1,11 @@
 import { TeamRole } from '@types'
-import { projectIdParamsSchema, groupIdParamsSchema } from '~~/server/db/zod'
+import { groupIdParamsSchema } from '~~/server/db/zod'
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug, { minRole: TeamRole.ADMIN })
-  await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+  const { project } = await requireUserTeamProject(event, { minRole: TeamRole.ADMIN })
   const { groupId } = await getValidatedRouterParams(event, groupIdParamsSchema.parse)
 
+  await new VariableGroupsService().getGroupForProject(groupId, project.id)
   await new VariableGroupsService().deleteGroup(groupId)
 
   return { statusCode: 200, message: 'Variable group deleted successfully' }

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.put.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.put.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { TeamRole } from '@types'
-import { projectIdParamsSchema, groupIdParamsSchema } from '~~/server/db/zod'
+import { groupIdParamsSchema } from '~~/server/db/zod'
 
 const updateGroupSchema = z.object({
   name: z.string().min(1).max(50).trim().optional(),
@@ -9,11 +9,11 @@ const updateGroupSchema = z.object({
 })
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug, { minRole: TeamRole.ADMIN })
-  await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+  const { project } = await requireUserTeamProject(event, { minRole: TeamRole.ADMIN })
   const { groupId } = await getValidatedRouterParams(event, groupIdParamsSchema.parse)
   const body = await readValidatedBody(event, updateGroupSchema.parse)
+
+  await new VariableGroupsService().getGroupForProject(groupId, project.id)
 
   const group = await new VariableGroupsService().updateGroup({
     id: groupId,

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/index.get.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/index.get.ts
@@ -1,9 +1,4 @@
-import { projectIdParamsSchema } from '~~/server/db/zod'
-
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
-
-  return await new VariableGroupsService().getGroups(projectId)
+  const { project } = await requireUserTeamProject(event)
+  return await new VariableGroupsService().getGroups(project.id)
 })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/index.post.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { TeamRole } from '@types'
-import { projectIdParamsSchema } from '~~/server/db/zod'
 
 const createGroupSchema = z.object({
   name: z.string({ error: 'Group name is required' }).min(1).max(50).trim(),
@@ -9,14 +8,12 @@ const createGroupSchema = z.object({
 })
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug, { minRole: TeamRole.ADMIN })
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+  const { project } = await requireUserTeamProject(event, { minRole: TeamRole.ADMIN })
   const body = await readValidatedBody(event, createGroupSchema.parse)
 
   const group = await new VariableGroupsService().createGroup({
     ...body,
-    projectId,
+    projectId: project.id,
   })
 
   return { statusCode: 201, group }

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.delete.ts
@@ -1,21 +1,17 @@
 import { TeamRole } from '@types'
-import { projectIdParamsSchema, variableIdParamsSchema } from '~~/server/db/zod'
+import { variableIdParamsSchema } from '~~/server/db/zod'
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  const { team } = await requireUserTeam(event, slug, { minRole: TeamRole.OWNER })
+  const { team, project } = await requireUserTeamProject(event, { minRole: TeamRole.OWNER })
   const { variableId } = await getValidatedRouterParams(event, variableIdParamsSchema.parse)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
 
   const existing = await db.query.variables.findFirst({
     where: and(
       eq(schema.variables.id, variableId),
-      eq(schema.variables.projectId, projectId),
+      eq(schema.variables.projectId, project.id),
     ),
   })
   if (!existing) throw createError({ statusCode: 404, statusMessage: 'Variable not found' })
-
-  const project = await new ProjectsService().getProject(existing.projectId)
 
   await new VariablesService(event).deleteVariable(variableId)
 
@@ -26,7 +22,7 @@ export default eventHandler(async (event) => {
     resourceId: variableId,
     metadata: {
       key: existing.key,
-      projectId: existing.projectId,
+      projectId: project.id,
       projectName: project.name,
     },
   })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { TeamRole } from '@types'
-import { projectIdParamsSchema, variableIdParamsSchema } from '~~/server/db/zod'
+import { variableIdParamsSchema } from '~~/server/db/zod'
 
 const updateVariableSchema = z.object({
   autoUppercase: z.boolean().optional(),
@@ -18,21 +18,18 @@ const updateVariableSchema = z.object({
 })
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  const { team } = await requireUserTeam(event, slug, { minRole: TeamRole.ADMIN })
+  const { team, project } = await requireUserTeamProject(event, { minRole: TeamRole.ADMIN })
   const { variableId } = await getValidatedRouterParams(event, variableIdParamsSchema.parse)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
   const body = await readValidatedBody(event, updateVariableSchema.parse)
 
   const existing = await db.query.variables.findFirst({
     where: and(
       eq(schema.variables.id, variableId),
-      eq(schema.variables.projectId, projectId),
+      eq(schema.variables.projectId, project.id),
     ),
   })
   if (!existing) throw createError({ statusCode: 404, statusMessage: 'Variable not found' })
 
-  const project = await new ProjectsService().getProject(existing.projectId)
   const environmentIds = [...new Set(body.values.map(v => v.environmentId))]
   await assertPushAllowedForEnvironmentIds(environmentIds, team.id, project.syncPolicy)
 
@@ -52,7 +49,7 @@ export default eventHandler(async (event) => {
     resourceId: variableId,
     metadata: {
       key: body.autoUppercase ? body.key.toUpperCase() : body.key,
-      projectId: existing.projectId,
+      projectId: project.id,
       projectName: project.name,
     },
   })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/env/[envId].get.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/env/[envId].get.ts
@@ -1,11 +1,8 @@
 import { z } from 'zod'
 import type { EnvVarExport } from '@types'
-import { projectIdParamsSchema } from '~~/server/db/zod'
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  const { team } = await requireUserTeam(event, slug)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+  const { team, project } = await requireUserTeamProject(event)
   const { envId } = await getValidatedRouterParams(event, z.object({
     envId: z.coerce.number({
       error: 'Environment ID is required',
@@ -14,14 +11,12 @@ export default eventHandler(async (event) => {
 
   await requireTokenScope(event, {
     teamId: team.id,
-    projectId,
+    projectId: project.id,
     environmentId: envId,
     permission: 'read',
   })
 
   const variablesService = new VariablesService(event)
-
-  const project = await new ProjectsService().getProject(projectId)
   const environmentName = await getEnvironmentName(envId, team.id)
 
   void logAudit(event, {
@@ -30,16 +25,16 @@ export default eventHandler(async (event) => {
     resourceType: 'environment',
     resourceId: envId,
     metadata: {
-      projectId,
+      projectId: project.id,
       projectName: project.name,
       environmentName,
     },
   })
 
   variablesService.incrementStatAsync(team.id, 'pull')
-  const result = await variablesService.getVariables(projectId, envId)
+  const result = await variablesService.getVariables(project.id, envId)
 
-  if (!result) throw createError({ statusCode: 404, statusMessage: `Variables not found for project ${projectId} and environment ${envId}` })
+  if (!result) throw createError({ statusCode: 404, statusMessage: `Variables not found for project ${project.id} and environment ${envId}` })
 
   const decryptedVariables = await variablesService.decryptVariables(result)
 

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/group.patch.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/group.patch.ts
@@ -7,10 +7,12 @@ const bulkAssignGroupSchema = z.object({
 })
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug, { minRole: TeamRole.ADMIN })
+  const { project } = await requireUserTeamProject(event, { minRole: TeamRole.ADMIN })
   const { variableIds, groupId } = await readValidatedBody(event, bulkAssignGroupSchema.parse)
-  await new VariablesService(event).bulkAssignGroup(variableIds, groupId)
+  if (groupId !== null) {
+    await new VariableGroupsService().getGroupForProject(groupId, project.id)
+  }
+  await new VariablesService(event).bulkAssignGroup(project.id, variableIds, groupId)
   return {
     statusCode: 200,
     message: 'Variables assigned to group',

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.delete.ts
@@ -2,13 +2,12 @@ import { z } from 'zod'
 import { TeamRole } from '@types'
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  await requireUserTeam(event, slug, { minRole: TeamRole.OWNER })
+  const { project } = await requireUserTeamProject(event, { minRole: TeamRole.OWNER })
   const { variables } = await readValidatedBody(event, z.object({
     variables: z.array(z.number()).min(1).max(100),
   }).parse)
   const variablesService = new VariablesService(event)
-  await Promise.all(variables.map(id => variablesService.deleteVariable(id)))
+  await variablesService.deleteVariablesInProject(project.id, variables)
   return {
     statusCode: 200,
     message: 'Variables deleted',

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.get.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.get.ts
@@ -1,12 +1,8 @@
-import { projectIdParamsSchema } from '~~/server/db/zod'
-
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  const { team } = await requireUserTeam(event, slug)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+  const { team, project } = await requireUserTeamProject(event)
   const variablesService = new VariablesService(event)
   variablesService.incrementStatAsync(team.id, 'pull')
-  const encryptedVariables = await variablesService.getVariables(projectId)
+  const encryptedVariables = await variablesService.getVariables(project.id)
   if (!encryptedVariables)
     throw createError({ statusCode: 404, statusMessage: 'Project variables not found' })
   return await variablesService.decryptVariables(encryptedVariables)

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.post.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/index.post.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { projectIdParamsSchema } from '~~/server/db/zod'
 
 const createVariablesSchema = z.object({
   autoUppercase: z.boolean().optional(),
@@ -19,18 +18,15 @@ const createVariablesSchema = z.object({
 })
 
 export default eventHandler(async (event) => {
-  const slug = await getTeamSlugFromEvent(event)
-  const { team } = await requireUserTeam(event, slug)
+  const { team, project } = await requireUserTeamProject(event)
   const body = await readValidatedBody(event, createVariablesSchema.parse)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
-  const project = await new ProjectsService().getProject(projectId)
 
   await assertPushAllowedForEnvironmentIds(body.environmentIds, team.id, project.syncPolicy)
 
   for (const environmentId of body.environmentIds) {
     await requireTokenScope(event, {
       teamId: team.id,
-      projectId,
+      projectId: project.id,
       environmentId,
       permission: 'write',
     })
@@ -38,7 +34,7 @@ export default eventHandler(async (event) => {
 
   const variablesService = new VariablesService(event)
   await variablesService.createVariables(event, {
-    projectId,
+    projectId: project.id,
     autoUppercase: body.autoUppercase,
     environmentIds: body.environmentIds,
     variables: body.variables.map(variable => ({
@@ -55,7 +51,7 @@ export default eventHandler(async (event) => {
     teamId: team.id,
     action: 'variables.create',
     resourceType: 'project',
-    resourceId: projectId,
+    resourceId: project.id,
     metadata: {
       keys: body.variables.map(v => v.key),
       environmentIds: body.environmentIds,

--- a/apps/shelve/server/services/projects.ts
+++ b/apps/shelve/server/services/projects.ts
@@ -23,9 +23,12 @@ export class ProjectsService {
 
     const [updatedProject] = await db.update(schema.projects)
       .set(input)
-      .where(eq(schema.projects.id, input.id))
+      .where(and(
+        eq(schema.projects.id, input.id),
+        eq(schema.projects.teamId, input.teamId),
+      ))
       .returning()
-    if (!updatedProject) throw createError({ statusCode: 422, message: 'Failed to update project' })
+    if (!updatedProject) throw createError({ statusCode: 404, message: `Project not found with id ${input.id}` })
     await clearCache('Projects', updatedProject.teamId)
     await clearCache('Project', updatedProject.id)
 
@@ -39,6 +42,15 @@ export class ProjectsService {
     if (!project) throw createError({ statusCode: 404, message: `Project not found with id ${projectId}` })
     return project
   })
+
+  /** Resolves a project only when it belongs to the given team (prevents cross-tenant IDOR). */
+  async getProjectForTeam(projectId: number, teamId: number): Promise<Project> {
+    const project = await this.getProject(projectId)
+    if (project.teamId !== teamId) {
+      throw createError({ statusCode: 404, message: `Project not found with id ${projectId}` })
+    }
+    return project
+  }
 
   getProjects = withCache<Project[]>('Projects', (teamId: number) => {
     return db.query.projects.findMany({

--- a/apps/shelve/server/services/variable-groups.ts
+++ b/apps/shelve/server/services/variable-groups.ts
@@ -2,6 +2,17 @@ import type { VariableGroup, CreateVariableGroupInput, UpdateVariableGroupInput 
 
 export class VariableGroupsService {
 
+  async getGroupForProject(groupId: number, projectId: number): Promise<VariableGroup> {
+    const group = await db.query.variableGroups.findFirst({
+      where: and(
+        eq(schema.variableGroups.id, groupId),
+        eq(schema.variableGroups.projectId, projectId),
+      ),
+    })
+    if (!group) throw createError({ statusCode: 404, statusMessage: 'Variable group not found' })
+    return group
+  }
+
   async getGroups(projectId: number): Promise<VariableGroup[]> {
     return await db.query.variableGroups.findMany({
       where: eq(schema.variableGroups.projectId, projectId),

--- a/apps/shelve/server/services/variables.ts
+++ b/apps/shelve/server/services/variables.ts
@@ -194,17 +194,17 @@ export class VariablesService {
       : variables
   })
 
-  async bulkAssignGroup(variableIds: number[], groupId: number | null): Promise<void> {
+  async bulkAssignGroup(projectId: number, variableIds: number[], groupId: number | null): Promise<void> {
     if (!variableIds.length) return
 
     await db.update(schema.variables)
       .set({ groupId })
-      .where(inArray(schema.variables.id, variableIds))
+      .where(and(
+        eq(schema.variables.projectId, projectId),
+        inArray(schema.variables.id, variableIds),
+      ))
 
-    const first = await db.query.variables.findFirst({
-      where: eq(schema.variables.id, variableIds[0]!),
-    })
-    if (first) await clearCache('Variables', first.projectId)
+    await clearCache('Variables', projectId)
   }
 
   async deleteVariable(id: number): Promise<void> {
@@ -215,6 +215,23 @@ export class VariablesService {
     if (!deleted) throw createError({ statusCode: 404, statusMessage: `Variable not found with id ${id}` })
 
     await clearCache('Variables', deleted.projectId)
+  }
+
+  async deleteVariablesInProject(projectId: number, variableIds: number[]): Promise<void> {
+    if (!variableIds.length) return
+
+    const deleted = await db.delete(schema.variables)
+      .where(and(
+        eq(schema.variables.projectId, projectId),
+        inArray(schema.variables.id, variableIds),
+      ))
+      .returning()
+
+    if (deleted.length !== variableIds.length) {
+      throw createError({ statusCode: 404, statusMessage: 'One or more variables not found' })
+    }
+
+    await clearCache('Variables', projectId)
   }
 
   async decryptVariables(variables: Variable[]): Promise<Variable[]> {

--- a/apps/shelve/server/utils/auth.ts
+++ b/apps/shelve/server/utils/auth.ts
@@ -1,9 +1,7 @@
 import type { H3Event } from 'h3'
-import type { Member, Project, Team, TokenPermission, TokenScopes, User } from '@types'
+import type { Member, Team, TokenPermission, TokenScopes, User } from '@types'
 import { Role, TeamRole } from '@types'
 import { z } from 'zod'
-import { projectIdParamsSchema } from '~~/server/db/zod'
-import { ProjectsService } from '~~/server/services/projects'
 import { validateTeamAccess, validateTeamRole } from './validateAccess'
 
 const teamSlugSchema = z.object({
@@ -62,21 +60,6 @@ export async function requireUserTeam(
 export async function getTeamSlugFromEvent(event: H3Event): Promise<string> {
   const { slug } = await getValidatedRouterParams(event, teamSlugSchema.parse)
   return slug
-}
-
-/**
- * Requires team membership and that the route's projectId belongs to that team.
- * Use on all handlers under /api/teams/[slug]/projects/[projectId]/.
- */
-export async function requireUserTeamProject(
-  event: H3Event,
-  options?: { minRole?: TeamRole }
-): Promise<{ user: User; team: Team; member: Member; project: Project }> {
-  const slug = await getTeamSlugFromEvent(event)
-  const { user, team, member } = await requireUserTeam(event, slug, options)
-  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
-  const project = await new ProjectsService().getProjectForTeam(projectId, team.id)
-  return { user, team, member, project }
 }
 
 /**

--- a/apps/shelve/server/utils/auth.ts
+++ b/apps/shelve/server/utils/auth.ts
@@ -1,7 +1,9 @@
 import type { H3Event } from 'h3'
-import type { Member, Team, TokenPermission, TokenScopes, User } from '@types'
+import type { Member, Project, Team, TokenPermission, TokenScopes, User } from '@types'
 import { Role, TeamRole } from '@types'
 import { z } from 'zod'
+import { projectIdParamsSchema } from '~~/server/db/zod'
+import { ProjectsService } from '~~/server/services/projects'
 import { validateTeamAccess, validateTeamRole } from './validateAccess'
 
 const teamSlugSchema = z.object({
@@ -60,6 +62,21 @@ export async function requireUserTeam(
 export async function getTeamSlugFromEvent(event: H3Event): Promise<string> {
   const { slug } = await getValidatedRouterParams(event, teamSlugSchema.parse)
   return slug
+}
+
+/**
+ * Requires team membership and that the route's projectId belongs to that team.
+ * Use on all handlers under /api/teams/[slug]/projects/[projectId]/.
+ */
+export async function requireUserTeamProject(
+  event: H3Event,
+  options?: { minRole?: TeamRole }
+): Promise<{ user: User; team: Team; member: Member; project: Project }> {
+  const slug = await getTeamSlugFromEvent(event)
+  const { user, team, member } = await requireUserTeam(event, slug, options)
+  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+  const project = await new ProjectsService().getProjectForTeam(projectId, team.id)
+  return { user, team, member, project }
 }
 
 /**

--- a/apps/shelve/server/utils/teamProject.ts
+++ b/apps/shelve/server/utils/teamProject.ts
@@ -1,0 +1,21 @@
+import type { H3Event } from 'h3'
+import type { Member, Project, Team, User } from '@types'
+import { TeamRole } from '@types'
+import { projectIdParamsSchema } from '../db/zod'
+import { ProjectsService } from '../services/projects'
+import { getTeamSlugFromEvent, requireUserTeam } from './auth'
+
+/**
+ * Requires team membership and that the route's projectId belongs to that team.
+ * Use on all handlers under /api/teams/[slug]/projects/[projectId]/.
+ */
+export async function requireUserTeamProject(
+  event: H3Event,
+  options?: { minRole?: TeamRole }
+): Promise<{ user: User; team: Team; member: Member; project: Project }> {
+  const slug = await getTeamSlugFromEvent(event)
+  const { user, team, member } = await requireUserTeam(event, slug, options)
+  const { projectId } = await getValidatedRouterParams(event, projectIdParamsSchema.parse)
+  const project = await new ProjectsService().getProjectForTeam(projectId, team.id)
+  return { user, team, member, project }
+}

--- a/apps/shelve/test/unit/team-project-context.test.ts
+++ b/apps/shelve/test/unit/team-project-context.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { Project } from '@types'
+
+vi.stubGlobal('createError', (opts: { statusCode: number; message?: string }) => {
+  const err = new Error(opts.message ?? '') as Error & { statusCode: number }
+  err.statusCode = opts.statusCode
+  return err
+})
+vi.stubGlobal('withCache', (_entity: string, fn: (...args: unknown[]) => unknown) => fn)
+
+const projectOnA = { id: 10, teamId: 1, name: 'app' } as Project
+const projectOnB = { id: 20, teamId: 2, name: 'other' } as Project
+
+describe('ProjectsService.getProjectForTeam', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  test('returns the project when it belongs to the team', async () => {
+    const { ProjectsService } = await import('../../server/services/projects')
+    const service = new ProjectsService()
+    vi.spyOn(service, 'getProject').mockResolvedValue(projectOnA)
+
+    await expect(service.getProjectForTeam(projectOnA.id, 1)).resolves.toEqual(projectOnA)
+  })
+
+  test('returns 404 when the project belongs to another team', async () => {
+    const { ProjectsService } = await import('../../server/services/projects')
+    const service = new ProjectsService()
+    vi.spyOn(service, 'getProject').mockResolvedValue(projectOnB)
+
+    await expect(service.getProjectForTeam(projectOnB.id, 1)).rejects.toMatchObject({
+      statusCode: 404,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Centralize team + project resolution for nested project routes
- Align bulk variable and group handlers with the project from the URL

## Test plan

- [x] `pnpm test test/unit/team-project-context.test.ts` (apps/shelve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved API endpoint security and consistency by aligning nested project handlers with proper team context validation from URL paths, preventing unauthorized cross-team access.

* **Chores**
  * Refactored internal API infrastructure to streamline team and project context resolution across all project-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->