### PR TITLE
refactor(app): tighten nested project route validations

### DIFF
--- a/.changeset/team-project-context.md
+++ b/.changeset/team-project-context.md
@@ -2,4 +2,4 @@
 "@shelve/app": patch
 ---
 
-Align nested project API handlers with the team from the URL path.
+Align nested project API handlers with the team from the URL path and tighten bulk project mutations.

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.delete.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.delete.ts
@@ -5,8 +5,7 @@ export default eventHandler(async (event) => {
   const { project } = await requireUserTeamProject(event, { minRole: TeamRole.ADMIN })
   const { groupId } = await getValidatedRouterParams(event, groupIdParamsSchema.parse)
 
-  await new VariableGroupsService().getGroupForProject(groupId, project.id)
-  await new VariableGroupsService().deleteGroup(groupId)
+  await new VariableGroupsService().deleteGroup(groupId, project.id)
 
   return { statusCode: 200, message: 'Variable group deleted successfully' }
 })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.put.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variable-groups/[groupId]/index.put.ts
@@ -13,12 +13,10 @@ export default eventHandler(async (event) => {
   const { groupId } = await getValidatedRouterParams(event, groupIdParamsSchema.parse)
   const body = await readValidatedBody(event, updateGroupSchema.parse)
 
-  await new VariableGroupsService().getGroupForProject(groupId, project.id)
-
   const group = await new VariableGroupsService().updateGroup({
     id: groupId,
     ...body,
-  })
+  }, project.id)
 
   return { statusCode: 200, group }
 })

--- a/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
+++ b/apps/shelve/server/api/teams/[slug]/projects/[projectId]/variables/[variableId]/index.put.ts
@@ -30,6 +30,10 @@ export default eventHandler(async (event) => {
   })
   if (!existing) throw createError({ statusCode: 404, statusMessage: 'Variable not found' })
 
+  if (body.groupId != null) {
+    await new VariableGroupsService().getGroupForProject(body.groupId, project.id)
+  }
+
   const environmentIds = [...new Set(body.values.map(v => v.environmentId))]
   await assertPushAllowedForEnvironmentIds(environmentIds, team.id, project.syncPolicy)
 

--- a/apps/shelve/server/services/projects.ts
+++ b/apps/shelve/server/services/projects.ts
@@ -15,11 +15,10 @@ export class ProjectsService {
   }
 
   async updateProject(input: ProjectUpdateInput): Promise<Project> {
-    const existingProject = await this.getProject(input.id)
-    if (!existingProject) throw createError({ statusCode: 404, message: `Project not found with id ${input.id}` })
+    const existingProject = await this.getProjectForTeam(input.id, input.teamId)
 
     if (existingProject.name !== input.name)
-      await this.validateProjectName(input.name, existingProject.teamId, input.id)
+      await this.validateProjectName(input.name, input.teamId, input.id)
 
     const [updatedProject] = await db.update(schema.projects)
       .set(input)

--- a/apps/shelve/server/services/variable-groups.ts
+++ b/apps/shelve/server/services/variable-groups.ts
@@ -35,7 +35,7 @@ export class VariableGroupsService {
     return group
   }
 
-  async updateGroup(input: UpdateVariableGroupInput): Promise<VariableGroup> {
+  async updateGroup(input: UpdateVariableGroupInput, projectId: number): Promise<VariableGroup> {
     const updates: Record<string, unknown> = {}
     if (input.name !== undefined) updates.name = input.name
     if (input.description !== undefined) updates.description = input.description
@@ -43,7 +43,10 @@ export class VariableGroupsService {
 
     const [group] = await db.update(schema.variableGroups)
       .set(updates)
-      .where(eq(schema.variableGroups.id, input.id))
+      .where(and(
+        eq(schema.variableGroups.id, input.id),
+        eq(schema.variableGroups.projectId, projectId),
+      ))
       .returning()
 
     if (!group) throw createError({ statusCode: 404, statusMessage: 'Variable group not found' })
@@ -51,9 +54,12 @@ export class VariableGroupsService {
     return group
   }
 
-  async deleteGroup(id: number): Promise<void> {
+  async deleteGroup(id: number, projectId: number): Promise<void> {
     const [deleted] = await db.delete(schema.variableGroups)
-      .where(eq(schema.variableGroups.id, id))
+      .where(and(
+        eq(schema.variableGroups.id, id),
+        eq(schema.variableGroups.projectId, projectId),
+      ))
       .returning()
 
     if (!deleted) throw createError({ statusCode: 404, statusMessage: 'Variable group not found' })

--- a/apps/shelve/server/services/variables.ts
+++ b/apps/shelve/server/services/variables.ts
@@ -194,8 +194,23 @@ export class VariablesService {
       : variables
   })
 
+  private async requireVariablesInProject(projectId: number, variableIds: number[]): Promise<void> {
+    const found = await db.query.variables.findMany({
+      where: and(
+        eq(schema.variables.projectId, projectId),
+        inArray(schema.variables.id, variableIds),
+      ),
+      columns: { id: true },
+    })
+    if (found.length !== variableIds.length) {
+      throw createError({ statusCode: 404, statusMessage: 'One or more variables not found' })
+    }
+  }
+
   async bulkAssignGroup(projectId: number, variableIds: number[], groupId: number | null): Promise<void> {
     if (!variableIds.length) return
+
+    await this.requireVariablesInProject(projectId, variableIds)
 
     await db.update(schema.variables)
       .set({ groupId })
@@ -220,16 +235,13 @@ export class VariablesService {
   async deleteVariablesInProject(projectId: number, variableIds: number[]): Promise<void> {
     if (!variableIds.length) return
 
-    const deleted = await db.delete(schema.variables)
+    await this.requireVariablesInProject(projectId, variableIds)
+
+    await db.delete(schema.variables)
       .where(and(
         eq(schema.variables.projectId, projectId),
         inArray(schema.variables.id, variableIds),
       ))
-      .returning()
-
-    if (deleted.length !== variableIds.length) {
-      throw createError({ statusCode: 404, statusMessage: 'One or more variables not found' })
-    }
 
     await clearCache('Variables', projectId)
   }

--- a/apps/shelve/test/unit/team-project-context.test.ts
+++ b/apps/shelve/test/unit/team-project-context.test.ts
@@ -19,18 +19,20 @@ describe('ProjectsService.getProjectForTeam', () => {
   test('returns the project when it belongs to the team', async () => {
     const { ProjectsService } = await import('../../server/services/projects')
     const service = new ProjectsService()
-    vi.spyOn(service, 'getProject').mockResolvedValue(projectOnA)
+    const getProject = vi.spyOn(service, 'getProject').mockResolvedValue(projectOnA)
 
     await expect(service.getProjectForTeam(projectOnA.id, 1)).resolves.toEqual(projectOnA)
+    expect(getProject).toHaveBeenCalledWith(projectOnA.id)
   })
 
   test('returns 404 when the project belongs to another team', async () => {
     const { ProjectsService } = await import('../../server/services/projects')
     const service = new ProjectsService()
-    vi.spyOn(service, 'getProject').mockResolvedValue(projectOnB)
+    const getProject = vi.spyOn(service, 'getProject').mockResolvedValue(projectOnB)
 
     await expect(service.getProjectForTeam(projectOnB.id, 1)).rejects.toMatchObject({
       statusCode: 404,
     })
+    expect(getProject).toHaveBeenCalledWith(projectOnB.id)
   })
 })


### PR DESCRIPTION
## Summary

- Validate bulk variable operations before writes
- Scope group update/delete and variable group assignment to the route project

## Test plan

- [x] `pnpm test test/unit/team-project-context.test.ts test/unit/token-scopes.test.ts` (apps/shelve)