### PR TITLE
docs(cli): document monorepo fan-out for diff, sync and agent output

### DIFF
--- a/apps/lp/content/docs/3.cli/10.agents-automation.md
+++ b/apps/lp/content/docs/3.cli/10.agents-automation.md
@@ -76,7 +76,7 @@ In agent shells, **`shelve pull` without `--yes` fails immediately** with code `
 | `push` | `{ env, variableCount, pushed, skippedKeys[], conflictKeys[] }` |
 | `pull` | `{ env, variableCount, file, keys[], pullMode, preservedLocalKeys[] }` — no values |
 | `diff` | `{ env, file, policy, onlyLocal[], onlyRemote[], changed[], unchanged[] }` — key names only |
-| `sync` | `{ env, action, variableCount, file, pullMode, keys[] }`; `--dry-run` returns `{ env, action, policy, diff, dryRun: true }` |
+| `sync` | pull: `{ env, action: "pull", variableCount, file, pullMode, keys[] }` (`{ env, action, variableCount: 0 }` when nothing to pull); push: `{ env, action: "push", variableCount, pushed, skippedKeys[], conflictKeys[] }`; `--dry-run`: `{ env, action, policy, diff, dryRun: true }` |
 | `init` | `{ writtenFiles, skippedFiles, gitignoreUpdated }` |
 | `login` | `{ username, email }` |
 | `create` | `{ name, slug, configPath }` |
@@ -84,7 +84,7 @@ In agent shells, **`shelve pull` without `--yes` fails immediately** with code `
 | `generate` | `{ type, path }` |
 | `upgrade` | `{ previous, current, updated }` |
 
-Run `push`, `pull`, `diff` or `sync` from a monorepo root and `data` becomes `{ "packages": [...] }` instead — one entry per package, each carrying the shape above plus its `path`. `--path <dir>` runs a single package and returns the plain shape. See [Monorepo support](/docs/cli#monorepo-support).
+Run `push`, `pull`, `diff` or `sync` from a monorepo root and `data` becomes `{ "packages": [...] }` instead — one entry per package, each carrying the shape above plus its `path`. `--path <dir>` runs a single package; the result keeps the `packages` envelope, with one entry. See [Monorepo support](/docs/cli#monorepo-support).
 
 When a package fails mid-run the error carries `context: { failedPackage, completedPackages[] }`, so you can tell how far the run got.
 

--- a/apps/lp/content/docs/3.cli/10.agents-automation.md
+++ b/apps/lp/content/docs/3.cli/10.agents-automation.md
@@ -73,14 +73,20 @@ In agent shells, **`shelve pull` without `--yes` fails immediately** with code `
 | `doctor` | `{ healthy, checks[], exitCodes, errorCodes }` |
 | `config` | Merged config; `token` redacted as `"***"` |
 | `me` | `{ loggedIn, username?, email? }` |
-| `push` | `{ env, variableCount, pushed }` |
-| `pull` | `{ env, variableCount, file, keys[] }` — no values |
+| `push` | `{ env, variableCount, pushed, skippedKeys[], conflictKeys[] }` |
+| `pull` | `{ env, variableCount, file, keys[], pullMode, preservedLocalKeys[] }` — no values |
+| `diff` | `{ env, file, policy, onlyLocal[], onlyRemote[], changed[], unchanged[] }` — key names only |
+| `sync` | `{ env, action, variableCount, file, pullMode, keys[] }`; `--dry-run` returns `{ env, action, policy, diff, dryRun: true }` |
 | `init` | `{ writtenFiles, skippedFiles, gitignoreUpdated }` |
 | `login` | `{ username, email }` |
 | `create` | `{ name, slug, configPath }` |
 | `logout` | `{ loggedOut: true }` |
 | `generate` | `{ type, path }` |
 | `upgrade` | `{ previous, current, updated }` |
+
+Run `push`, `pull`, `diff` or `sync` from a monorepo root and `data` becomes `{ "packages": [...] }` instead — one entry per package, each carrying the shape above plus its `path`. `--path <dir>` runs a single package and returns the plain shape. See [Monorepo support](/docs/cli#monorepo-support).
+
+When a package fails mid-run the error carries `context: { failedPackage, completedPackages[] }`, so you can tell how far the run got.
 
 `shelve run` inherits the child stdio. Startup errors are structured on stderr; with `--json`, a spawn event is also emitted on stderr: `{ "ok": true, "event": "child_spawned", "env", "variableCount", "keys", "command", "pid" }`.
 

--- a/apps/lp/content/docs/3.cli/11.troubleshooting.md
+++ b/apps/lp/content/docs/3.cli/11.troubleshooting.md
@@ -19,6 +19,7 @@ shelve --json doctor
 | `CONFIG_MISSING` | No `shelve.json` and missing env | Create config or set `SHELVE_TEAM_SLUG` + `SHELVE_PROJECT` |
 | `MISSING_ENV` | No environment selected | `--env staging` or `defaultEnv` in config |
 | `MISSING_INPUT` | Non-interactive mode missing a flag | Pass the flag shown in the error hint |
+| `INVALID_INPUT` | Bad flag value, e.g. `--path` pointing at a directory with no `shelve.json` | Pass `--path` a directory holding a `shelve.json` |
 | `FETCH_FAILED` | Network/API failure, no cache | Go online once, or use `--offline` if cache exists |
 | `FORBIDDEN` | Token lacks scope | Create a token with read/write for the team/project |
 | `PROJECT_NOT_FOUND` | Project missing | Enable `autoCreateProject` or `shelve create` |
@@ -28,6 +29,24 @@ shelve --json doctor
 | `ENV_PROTECTED` | Server blocked write to protected env | Update project sync policy in Shelve settings |
 
 See also `shelve --help` for the full list of structured error codes.
+
+## Monorepo runs
+
+`push`, `pull`, `diff` and `sync` run once per package when started from a workspace root. A failing package stops the run, and packages already processed have written to disk by then. The error names the package that failed and the ones that completed, in the hint and in `context` under `--json`:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "PUSH_BLOCKED",
+    "message": "apps/api: Push to \"production\" is blocked by sync policy.",
+    "hint": "Remove the environment from sync.protectedEnvironments or set allowPush: true. Already completed: apps/web.",
+    "context": { "failedPackage": "apps/api", "completedPackages": ["apps/web"] }
+  }
+}
+```
+
+Fix the named package, then re-run. Use `--path <dir>` to retry just that one.
 
 ## Exit codes
 

--- a/apps/lp/content/docs/3.cli/11.troubleshooting.md
+++ b/apps/lp/content/docs/3.cli/11.troubleshooting.md
@@ -32,16 +32,16 @@ See also `shelve --help` for the full list of structured error codes.
 
 ## Monorepo runs
 
-`push`, `pull`, `diff` and `sync` run once per package when started from a workspace root. A failing package stops the run, and packages already processed have written to disk by then. The error names the package that failed and the ones that completed, in the hint and in `context` under `--json`:
+`push`, `pull`, `diff` and `sync` run once per package when started from a workspace root. A failing package stops the run; the packages before it have already been applied (a `pull` has written its env file, a `push` has reached Shelve). The error names the package that failed and the ones that completed, in the hint and in `context` under `--json`:
 
 ```json
 {
   "ok": false,
   "error": {
     "code": "PUSH_BLOCKED",
-    "message": "apps/api: Push to \"production\" is blocked by sync policy.",
-    "hint": "Remove the environment from sync.protectedEnvironments or set allowPush: true. Already completed: apps/web.",
-    "context": { "failedPackage": "apps/api", "completedPackages": ["apps/web"] }
+    "message": "apps/web: Push to \"production\" is blocked by sync policy.",
+    "hint": "Remove the environment from sync.protectedEnvironments or set allowPush: true. Already completed: apps/api.",
+    "context": { "failedPackage": "apps/web", "completedPackages": ["apps/api"] }
   }
 }
 ```

--- a/apps/lp/content/docs/3.cli/12.sync-policies.md
+++ b/apps/lp/content/docs/3.cli/12.sync-policies.md
@@ -63,6 +63,7 @@ Compare local `envFileName` with Shelve (no writes). Safe for agents with `--jso
 shelve diff --env staging
 shelve --json diff --env staging
 shelve diff --env staging --show-values
+shelve diff --env staging --path apps/web
 ```
 
 ### `shelve sync` {#sync-command}
@@ -76,6 +77,7 @@ Apply the effective policy for the environment:
 shelve sync --env development
 shelve sync --env production --dry-run
 shelve sync --yes --env staging
+shelve sync --env development --path apps/web
 ```
 
 `--dry-run` reports the planned action and diff without writing.
@@ -101,3 +103,5 @@ See [Troubleshooting](/docs/cli/troubleshooting).
 ## Monorepos
 
 Put `protectedEnvironments` in the **root** `shelve.json`; package-level files can override `sync.environments` for each app.
+
+Run from the workspace root and `diff` and `sync` visit every package that has its own `shelve.json`, each under its own policy. `--path <dir>` targets one package instead. With `--json` the result becomes `{ "packages": [...] }`, one entry per package with its `path`. See [Monorepo support](/docs/cli#monorepo-support).

--- a/apps/lp/skills/shelve/SKILL.md
+++ b/apps/lp/skills/shelve/SKILL.md
@@ -74,6 +74,9 @@ shelve push --env development --yes
 shelve pull --env development --yes   # risky in agent shells
 shelve sync --dry-run --env production
 
+# Monorepo: from the root these four run once per package
+shelve pull --path apps/web           # ...or target a single package
+
 shelve create --name my-app --slug my-team
 shelve generate --type env-example
 ```
@@ -110,6 +113,17 @@ shelve generate --type env-example
 
 See **`sync-policies.md`** and https://shelve.cloud/docs/cli/sync-policies
 
+## Monorepos
+
+From a workspace root, `push` / `pull` / `diff` / `sync` run once per package that has its own `shelve.json`; the root itself and packages without one are skipped. `--path <dir>` targets a single package. `run` never fans out.
+
+- Root `shelve.json` holds shared settings (`slug`, `defaultEnv`, …); `project` stays per-package and is never inherited.
+- Give the root a `project` to opt out and treat it as one project.
+- With `--json`, `data` becomes `{ "packages": [...] }`, one entry per package with its `path`.
+- A failing package stops the run; the error carries `context: { failedPackage, completedPackages }`.
+
+Details: **`agent-workflows.md`**
+
 ## Error codes
 
 | Code | Meaning |
@@ -121,6 +135,7 @@ See **`sync-policies.md`** and https://shelve.cloud/docs/cli/sync-policies
 | `PUSH_BLOCKED` / `PULL_BLOCKED` | Sync policy |
 | `SYNC_CONFLICT` | `onPushConflict: fail` or prompt in CI |
 | `ENV_PROTECTED` | Server blocked push to protected env |
+| `INVALID_INPUT` | Bad flag value, e.g. `--path` with no `shelve.json` there |
 
 ## Reference files (read when needed)
 

--- a/apps/lp/skills/shelve/cli-commands.md
+++ b/apps/lp/skills/shelve/cli-commands.md
@@ -23,6 +23,22 @@
 
 Apply to every command: `--json`, `--quiet` / `-q`, `--yes` / `-y`, `--non-interactive`, `--debug`.
 
+## Command flags
+
+| Command | Flags |
+|---------|-------|
+| `push` | `--env`, `--path`, `--yes` |
+| `pull` | `--env`, `--path`, `--yes` |
+| `diff` | `--env`, `--path`, `--show-values` |
+| `sync` | `--env`, `--path`, `--dry-run`, `--yes` |
+| `run` | `--env`, `--template`, `--offline`, `--no-cache`, `--cache-ttl`, `--watch`, `--restart-on-change` |
+| `login` | `--token` / `--with-token` |
+| `create` | `--name`, `--slug` |
+| `generate` | `--type env-example \| eslint` |
+| `init` | `--cwd` |
+
+`--path <dir>` runs a single monorepo package instead of every one.
+
 ## JSON success shape
 
 ```json
@@ -59,7 +75,7 @@ or `{ "loggedIn": false }`.
 ### `push`
 
 ```json
-{ "env": "development", "variableCount": 12, "pushed": true }
+{ "env": "development", "variableCount": 12, "pushed": true, "skippedKeys": [], "conflictKeys": [] }
 ```
 
 ### `pull`
@@ -69,21 +85,13 @@ or `{ "loggedIn": false }`.
   "env": "development",
   "variableCount": 12,
   "file": ".env",
-  "keys": ["DATABASE_URL", "API_KEY"]
+  "keys": ["DATABASE_URL", "API_KEY"],
+  "pullMode": "replace",
+  "preservedLocalKeys": []
 }
 ```
 
 Values are **never** included.
-
-Run from a monorepo root and the shape becomes one entry per package:
-
-```json
-{
-  "packages": [
-    { "path": "apps/web", "env": "development", "variableCount": 12, "file": ".env", "keys": ["DATABASE_URL"] }
-  ]
-}
-```
 
 ### `init`
 
@@ -121,16 +129,6 @@ Types: `env-example`, `eslint` (via `--type`).
 { "previous": "5.0.3", "current": "latest", "updated": true }
 ```
 
-## Exit codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | Error |
-| 128+n | Child signal exit (`run`) |
-| 129 | Parent gone / EIO |
-| 130 / 143 | SIGINT / SIGTERM |
-
 ### `diff`
 
 ```json
@@ -148,8 +146,34 @@ Types: `env-example`, `eslint` (via `--type`).
 ### `sync`
 
 ```json
-{ "env": "development", "action": "pull", "variableCount": 12, "file": ".env" }
+{ "env": "development", "action": "pull", "variableCount": 12, "file": ".env", "pullMode": "replace", "keys": ["DATABASE_URL"] }
 ```
+
+`--dry-run` returns `{ "env", "action", "policy", "diff", "dryRun": true }` and writes nothing.
+
+### Monorepo fan-out (`push`, `pull`, `diff`, `sync`)
+
+Run from a workspace root and `data` becomes one entry per package, each carrying that command's shape plus its `path`:
+
+```json
+{
+  "packages": [
+    { "path": "apps/web", "env": "development", "variableCount": 12, "file": ".env", "keys": ["DATABASE_URL"] }
+  ]
+}
+```
+
+`--path apps/web` runs a single package and returns the plain shape. A failing package stops the run; the error carries `context: { "failedPackage", "completedPackages" }`.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error |
+| 128+n | Child signal exit (`run`) |
+| 129 | Parent gone / EIO |
+| 130 / 143 | SIGINT / SIGTERM |
 
 ## Error codes (automation)
 
@@ -159,6 +183,7 @@ Types: `env-example`, `eslint` (via `--type`).
 | `PULL_BLOCKED` | Pull disabled by sync policy |
 | `SYNC_CONFLICT` | Diverging keys with `onPushConflict: fail` |
 | `ENV_PROTECTED` | Server blocked write to protected environment |
+| `INVALID_INPUT` | Bad flag value, e.g. `--path` with no `shelve.json` there |
 
 ## Environment variables
 

--- a/apps/lp/skills/shelve/cli-commands.md
+++ b/apps/lp/skills/shelve/cli-commands.md
@@ -32,7 +32,7 @@ Apply to every command: `--json`, `--quiet` / `-q`, `--yes` / `-y`, `--non-inter
 | `diff` | `--env`, `--path`, `--show-values` |
 | `sync` | `--env`, `--path`, `--dry-run`, `--yes` |
 | `run` | `--env`, `--template`, `--offline`, `--no-cache`, `--cache-ttl`, `--watch`, `--restart-on-change` |
-| `login` | `--token` / `--with-token` |
+| `login` | `--token` / `--with-token`, `--no-browser` |
 | `create` | `--name`, `--slug` |
 | `generate` | `--type env-example \| eslint` |
 | `init` | `--cwd` |
@@ -149,7 +149,13 @@ Types: `env-example`, `eslint` (via `--type`).
 { "env": "development", "action": "pull", "variableCount": 12, "file": ".env", "pullMode": "replace", "keys": ["DATABASE_URL"] }
 ```
 
-`--dry-run` returns `{ "env", "action", "policy", "diff", "dryRun": true }` and writes nothing.
+When the policy pushes instead:
+
+```json
+{ "env": "development", "action": "push", "variableCount": 12, "pushed": true, "skippedKeys": [], "conflictKeys": [] }
+```
+
+A pull with nothing to write returns `{ "env", "action": "pull", "variableCount": 0 }`. `--dry-run` returns `{ "env", "action", "policy", "diff", "dryRun": true }` and writes nothing.
 
 ### Monorepo fan-out (`push`, `pull`, `diff`, `sync`)
 
@@ -163,7 +169,7 @@ Run from a workspace root and `data` becomes one entry per package, each carryin
 }
 ```
 
-`--path apps/web` runs a single package and returns the plain shape. A failing package stops the run; the error carries `context: { "failedPackage", "completedPackages" }`.
+`--path apps/web` runs a single package; the result keeps the `packages` envelope, with one entry. A failing package stops the run; the error carries `context: { "failedPackage", "completedPackages" }`.
 
 ## Exit codes
 

--- a/docs/agents/cli.md
+++ b/docs/agents/cli.md
@@ -48,7 +48,7 @@ Auto non-interactive when:
 
 | Command | Flags |
 |---------|-------|
-| `login` | Browser device flow by default; `--token` / `SHELVE_TOKEN` / `--with-token` for automation |
+| `login` | Browser device flow by default; `--token` / `SHELVE_TOKEN` / `--with-token` for automation; `--no-browser` prints the URL and code without opening a browser |
 | `push` / `pull` | `--env`, `--path`, `--yes` |
 | `diff` | `--env`, `--path`, `--show-values` |
 | `sync` | `--env`, `--path`, `--dry-run`, `--yes` |
@@ -67,7 +67,7 @@ Auto non-interactive when:
 | `push` | `{ env, variableCount, pushed, skippedKeys[], conflictKeys[] }` — never includes values |
 | `pull` | `{ env, variableCount, file, keys[], pullMode, preservedLocalKeys[] }` |
 | `diff` | `{ env, file, policy, onlyLocal[], onlyRemote[], changed[], unchanged[] }` |
-| `sync` | `{ env, action, variableCount, file, pullMode, keys[] }`; `--dry-run` returns `{ env, action, policy, diff, dryRun: true }` |
+| `sync` | pull: `{ env, action: "pull", variableCount, file, pullMode, keys[] }` (`{ env, action, variableCount: 0 }` when nothing to pull); push: `{ env, action: "push", variableCount, pushed, skippedKeys[], conflictKeys[] }`; `--dry-run`: `{ env, action, policy, diff, dryRun: true }` |
 | `init` | `{ writtenFiles, skippedFiles, gitignoreUpdated }` |
 | `login` | `{ username, email }` |
 | `create` | `{ name, slug, configPath }` |
@@ -75,7 +75,7 @@ Auto non-interactive when:
 | `generate` | `{ type, path }` |
 | `upgrade` | `{ previous, current, updated }` |
 
-From a monorepo root, `push` / `pull` / `diff` / `sync` run once per package that has its own `shelve.json`, and `data` becomes `{ packages: [...] }` — one entry per package with its `path`. `--path <dir>` runs a single package and returns the plain shape. A failing package stops the run; the error carries `context: { failedPackage, completedPackages }`. `run` never fans out. See [Monorepo support](https://shelve.cloud/docs/cli#monorepo-support).
+From a monorepo root, `push` / `pull` / `diff` / `sync` run once per package that has its own `shelve.json`, and `data` becomes `{ packages: [...] }` — one entry per package with its `path`. `--path <dir>` runs a single package; the result keeps the `packages` envelope, with one entry. A failing package stops the run; the error carries `context: { failedPackage, completedPackages }`. `run` never fans out. See [Monorepo support](https://shelve.cloud/docs/cli#monorepo-support).
 
 `run` keeps the child process stdio inherited. Startup errors are structured on stderr; with `--json`, a spawn event is also emitted on stderr: `{ ok: true, event: "child_spawned", env, variableCount, keys, command, pid }`.
 

--- a/docs/agents/cli.md
+++ b/docs/agents/cli.md
@@ -49,7 +49,9 @@ Auto non-interactive when:
 | Command | Flags |
 |---------|-------|
 | `login` | Browser device flow by default; `--token` / `SHELVE_TOKEN` / `--with-token` for automation |
-| `push` / `pull` | `--env`, `--yes` |
+| `push` / `pull` | `--env`, `--path`, `--yes` |
+| `diff` | `--env`, `--path`, `--show-values` |
+| `sync` | `--env`, `--path`, `--dry-run`, `--yes` |
 | `create` | `--name`, `--slug` |
 | `generate` | `--type env-example \| eslint` |
 | `init` | `--cwd` |
@@ -62,13 +64,18 @@ Auto non-interactive when:
 | `doctor` | `{ healthy, checks[], exitCodes, errorCodes }` |
 | `config` | merged config, token redacted as `***` |
 | `me` | `{ loggedIn, username?, email? }` |
-| `push` / `pull` | `{ env, variableCount, pushed?, file?, keys? }` — never includes values |
+| `push` | `{ env, variableCount, pushed, skippedKeys[], conflictKeys[] }` — never includes values |
+| `pull` | `{ env, variableCount, file, keys[], pullMode, preservedLocalKeys[] }` |
+| `diff` | `{ env, file, policy, onlyLocal[], onlyRemote[], changed[], unchanged[] }` |
+| `sync` | `{ env, action, variableCount, file, pullMode, keys[] }`; `--dry-run` returns `{ env, action, policy, diff, dryRun: true }` |
 | `init` | `{ writtenFiles, skippedFiles, gitignoreUpdated }` |
 | `login` | `{ username, email }` |
 | `create` | `{ name, slug, configPath }` |
 | `logout` | `{ loggedOut: true }` |
 | `generate` | `{ type, path }` |
 | `upgrade` | `{ previous, current, updated }` |
+
+From a monorepo root, `push` / `pull` / `diff` / `sync` run once per package that has its own `shelve.json`, and `data` becomes `{ packages: [...] }` — one entry per package with its `path`. `--path <dir>` runs a single package and returns the plain shape. A failing package stops the run; the error carries `context: { failedPackage, completedPackages }`. `run` never fans out. See [Monorepo support](https://shelve.cloud/docs/cli#monorepo-support).
 
 `run` keeps the child process stdio inherited. Startup errors are structured on stderr; with `--json`, a spawn event is also emitted on stderr: `{ ok: true, event: "child_spawned", env, variableCount, keys, command, pid }`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -88,7 +88,14 @@ shelve run -- pnpm dev
 
 ### Monorepo usage
 
-In a monorepo, local `shelve.json` is merged with the root config (shared team slug, etc.). Commands run in the current package directory; they do not automatically iterate all packages.
+In a monorepo, local `shelve.json` is merged with the root config (shared team slug, `defaultEnv`, etc.); `project` stays per-package. From the workspace root, `push`, `pull`, `diff` and `sync` run once per package that has its own `shelve.json`, and `--path <dir>` targets a single one:
+
+```bash
+shelve pull                  # every package with a shelve.json
+shelve pull --path apps/web  # just one
+```
+
+Give the root `shelve.json` a `project` to opt out and treat the root as a single project. `run` always executes in the current directory.
 
 <!-- automd:fetch url="gh:hugorcd/markdown/main/src/local_development.md" -->
 


### PR DESCRIPTION
Follow-up to #766. That PR made `push`, `pull`, `diff` and `sync` run once per package from a monorepo root and updated the push/pull page, the config page and two skill files. The rest of the docs never caught up: no `--path` in any flag table, no mention of `diff` and `sync` fanning out, and JSON shapes that predate the sync-policy work.

Docs:
- `3.cli/12.sync-policies.md`: `--path` examples for `diff` and `sync`, and a note that both visit every package under its own policy
- `3.cli/10.agents-automation.md`: added the missing `diff` and `sync` rows, fixed `push` (`skippedKeys`, `conflictKeys`) and `pull` (`pullMode`, `preservedLocalKeys`), documented the `packages` envelope and the `context` an interrupted run carries
- `3.cli/11.troubleshooting.md`: `INVALID_INPUT`, plus what a run that fails halfway through the packages reports

Skill:
- `SKILL.md`: monorepo section, `--path` in the cheat sheet, `INVALID_INPUT` in the error table
- `cli-commands.md`: per-command flag table, corrected JSON shapes, one shared fan-out section replacing the pull-only example. Also moved `diff` and `sync` above the exit-code table, where they have been stranded since #752

Internal:
- `docs/agents/cli.md`: `--path` on push/pull, new `diff` and `sync` rows, split the merged push/pull JSON row, fan-out paragraph

Error strings in the new troubleshooting example are copied from `sync-policy.ts` and `workspaces.ts`, not invented. Every JSON shape was read off the command's return value.

No changeset: only `apps/lp` (private) and `docs/` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for running `push`, `pull`, `diff`, and `sync` across monorepo packages.
  - Documented `--path` for targeting a single package.
  - Expanded JSON output examples, including package results, dry-run data, skipped and conflicting keys, and pull details.
  - Added troubleshooting guidance for package failures, retries, and the new `INVALID_INPUT` error code.
  - Documented the `--no-browser` option for login and command-specific flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->